### PR TITLE
alignment settings

### DIFF
--- a/src/org/intellij/erlang/formatter/ErlangFormattingModelBuilder.java
+++ b/src/org/intellij/erlang/formatter/ErlangFormattingModelBuilder.java
@@ -25,6 +25,7 @@ import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.tree.TokenSet;
 import org.intellij.erlang.ErlangLanguage;
+import org.intellij.erlang.formatter.settings.ErlangCodeStyleSettings;
 import org.jetbrains.annotations.NotNull;
 
 import static org.intellij.erlang.ErlangTypes.*;
@@ -36,9 +37,10 @@ public class ErlangFormattingModelBuilder implements FormattingModelBuilder {
   @NotNull
   @Override
   public FormattingModel createModel(PsiElement element, CodeStyleSettings settings) {
-    CommonCodeStyleSettings erlangSettings = settings.getCommonSettings(ErlangLanguage.INSTANCE);
-    final ErlangBlock block = new ErlangBlock(null, element.getNode(), null, null, erlangSettings,
-      createSpacingBuilder(erlangSettings));
+    CommonCodeStyleSettings commonSettings = settings.getCommonSettings(ErlangLanguage.INSTANCE);
+    ErlangCodeStyleSettings erlangSettings = settings.getCustomSettings(ErlangCodeStyleSettings.class);
+    final ErlangBlock block = new ErlangBlock(null, element.getNode(), null, null, commonSettings, erlangSettings,
+      createSpacingBuilder(commonSettings));
     return FormattingModelProvider.createFormattingModelForPsiFile(element.getContainingFile(), block, settings);
   }
 

--- a/src/org/intellij/erlang/formatter/ErlangIndentProcessor.java
+++ b/src/org/intellij/erlang/formatter/ErlangIndentProcessor.java
@@ -75,13 +75,13 @@ public class ErlangIndentProcessor {
       if (elementType == ERL_CURLY_LEFT || elementType == ERL_CURLY_RIGHT) {
         return Indent.getNoneIndent();
       }
-      return Indent.getContinuationIndent();
+      return Indent.getNormalIndent();
     }
     if (parentType == ERL_LIST_EXPRESSION || parentType == ERL_LIST_COMPREHENSION || parentType == ERL_EXPORT_FUNCTIONS) {
       if (elementType == ERL_BRACKET_LEFT || elementType == ERL_BRACKET_RIGHT || elementType == ERL_BIN_START || elementType == ERL_BIN_END || elementType == ERL_LC_EXPRS) {
         return Indent.getNoneIndent();
       }
-      return Indent.getContinuationIndent();
+      return Indent.getNormalIndent();
     }
     if (parentType == ERL_GUARD || (parentType == ERL_CLAUSE_GUARD && elementType == ERL_WHEN)) {
       return Indent.getNormalIndent();

--- a/src/org/intellij/erlang/formatter/settings/ErlangCodeStyleSettings.java
+++ b/src/org/intellij/erlang/formatter/settings/ErlangCodeStyleSettings.java
@@ -1,0 +1,28 @@
+/*
+* Copyright 2012 Volodymyr Kyrychenko <vladimir.kirichenko@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.intellij.erlang.formatter.settings;
+
+import com.intellij.psi.codeStyle.CodeStyleSettings;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
+
+public class ErlangCodeStyleSettings extends CustomCodeStyleSettings {
+
+  public boolean ALIGN_MULTILINE_BLOCK = false;
+
+  protected ErlangCodeStyleSettings(CodeStyleSettings container) {
+    super("ErlangCodeStyleSettings", container);
+  }
+}

--- a/src/org/intellij/erlang/formatter/settings/ErlangCodeStyleSettingsProvider.java
+++ b/src/org/intellij/erlang/formatter/settings/ErlangCodeStyleSettingsProvider.java
@@ -19,6 +19,7 @@ package org.intellij.erlang.formatter.settings;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.psi.codeStyle.CodeStyleSettings;
 import com.intellij.psi.codeStyle.CodeStyleSettingsProvider;
+import com.intellij.psi.codeStyle.CustomCodeStyleSettings;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -34,5 +35,11 @@ public class ErlangCodeStyleSettingsProvider extends CodeStyleSettingsProvider {
   @Override
   public Configurable createSettingsPage(CodeStyleSettings settings, CodeStyleSettings originalSettings) {
     return new ErlangCodeStyleConfigurable(settings, originalSettings);
+  }
+
+  @NotNull
+  @Override
+  public CustomCodeStyleSettings createCustomSettings(CodeStyleSettings settings) {
+    return new ErlangCodeStyleSettings(settings);
   }
 }

--- a/src/org/intellij/erlang/formatter/settings/ErlangLanguageCodeStyleSettingsProvider.java
+++ b/src/org/intellij/erlang/formatter/settings/ErlangLanguageCodeStyleSettingsProvider.java
@@ -112,6 +112,7 @@ public class ErlangLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSe
 //        "PARENTHESES_EXPRESSION_LPAREN_WRAP",
 //        "PARENTHESES_EXPRESSION_RPAREN_WRAP"
       );
+      consumer.showCustomOption(ErlangCodeStyleSettings.class, "ALIGN_MULTILINE_BLOCK", "Align when multiple", "Blocks (fun...end, etc)");
     }
   }
 
@@ -144,14 +145,14 @@ public class ErlangLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSe
       "    spawn(tut15, ping, [30, Pong_PID]).";
 
   public static final String WRAPPING_CODE_SAMPLE =
-    "%% ping comment" +
+    "%% ping comment\n" +
       "ping(0, Pong_PID) ->\n" +
       "    Pong_PID ! finished,\n" +
       "    tut15:pong(),\n" +
       "    io:format(\"Ping finished~n\", []);\n" +
       "\n" +
       "" +
-      "%% pong comment" +
+      "%% pong comment\n" +
       "ping(N, Pong_PID)->\n" +
       "    Pong_PID ! {ping, self()},\n" +
       "    receive\n" +


### PR DESCRIPTION
- option to enable/disable emacs style function alignment
- declaration of multiline lists, tuples and records use normal indent, not continuation
