### PR TITLE
Basic support for Erlang copyright

### DIFF
--- a/src/META-INF/erlang-copyright.xml
+++ b/src/META-INF/erlang-copyright.xml
@@ -1,0 +1,5 @@
+<idea-plugin>
+    <extensions defaultExtensionNs="com.intellij.copyright">
+        <updater filetype="Erlang" implementationClass="org.intellij.erlang.copyright.UpdateErlangCopyrightsProvider"/>
+    </extensions>
+</idea-plugin>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -5,6 +5,8 @@
     <idea-version since-build="117.105" until-build="120.1"/>
     <depends>com.intellij.modules.lang</depends>
 
+    <depends optional="true" config-file="erlang-copyright.xml">com.intellij.copyright</depends>
+
     <name>Erlang</name>
     <description>Erlang plugin</description>
     <change-notes>

--- a/src/org/intellij/erlang/copyright/UpdateErlangCopyrightsProvider.java
+++ b/src/org/intellij/erlang/copyright/UpdateErlangCopyrightsProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2012 Sergey Ignatov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.erlang.copyright;
+
+import com.intellij.openapi.fileTypes.FileType;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.maddyhome.idea.copyright.CopyrightProfile;
+import com.maddyhome.idea.copyright.options.LanguageOptions;
+import com.maddyhome.idea.copyright.psi.UpdateCopyright;
+import com.maddyhome.idea.copyright.psi.UpdateCopyrightsProvider;
+
+
+public class UpdateErlangCopyrightsProvider extends UpdateCopyrightsProvider {
+
+  @Override
+  public UpdateCopyright createInstance(Project project, Module module, VirtualFile file, FileType base,
+                                        CopyrightProfile options) {
+    return new UpdateErlangFileCopyright(project, module, file, options);
+  }
+
+
+  @Override
+  public LanguageOptions getDefaultOptions() {
+    LanguageOptions options = super.getDefaultOptions();
+    options.setFiller('=');
+    options.setBlock(false);
+    options.setPrefixLines(true);
+    return options;
+  }
+}

--- a/src/org/intellij/erlang/copyright/UpdateErlangFileCopyright.java
+++ b/src/org/intellij/erlang/copyright/UpdateErlangFileCopyright.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2012 Sergey Ignatov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.erlang.copyright;
+
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiComment;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiWhiteSpace;
+import com.maddyhome.idea.copyright.CopyrightProfile;
+import com.maddyhome.idea.copyright.psi.UpdatePsiFileCopyright;
+import org.intellij.erlang.psi.ErlangFile;
+
+public class UpdateErlangFileCopyright extends UpdatePsiFileCopyright {
+
+  public UpdateErlangFileCopyright(Project project, Module module, VirtualFile root, CopyrightProfile options) {
+    super(project, module, root, options);
+  }
+
+  @Override
+  protected boolean accept() {
+    return getFile() instanceof ErlangFile;
+  }
+
+  protected void scanFile() {
+    PsiElement first = getFile().getFirstChild();
+    PsiElement last = first;
+    PsiElement next = first;
+    while (next != null) {
+      if (next instanceof PsiComment || next instanceof PsiWhiteSpace) {
+        next = getNextSibling(next);
+      }
+      else {
+        break;
+      }
+      last = next;
+    }
+
+    if (first != null) {
+      checkComments(first, last, true);
+    }
+    else {
+      checkComments(null, null, true);
+    }
+  }
+}


### PR DESCRIPTION
Note that introduces dependency on copyright plugin that comes bundled with Idea, but I did not update the plugin project file to include this dependency. I though that you would rather do that the way you like.
