### PR TITLE
Fix relative file links in Rebar console

### DIFF
--- a/src/org/intellij/erlang/rebar/runner/RebarRunConfiguration.java
+++ b/src/org/intellij/erlang/rebar/runner/RebarRunConfiguration.java
@@ -36,7 +36,7 @@ public final class RebarRunConfiguration extends RuntimeConfiguration implements
   @NotNull private String myCommand = "";
 
   public RebarRunConfiguration(@NotNull String name, @NotNull Project project) {
-    super(name, project, RebarRunConfigFactory.getInstance());
+    super(name, project, RebarRunConfigurationFactory.getInstance());
   }
 
   @NotNull

--- a/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationFactory.java
+++ b/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationFactory.java
@@ -24,10 +24,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import org.jetbrains.annotations.NotNull;
 
-final class RebarRunConfigFactory extends ConfigurationFactory {
-  private static final RebarRunConfigFactory ourInstance = new RebarRunConfigFactory();
+final class RebarRunConfigurationFactory extends ConfigurationFactory {
+  private static final RebarRunConfigurationFactory ourInstance = new RebarRunConfigurationFactory();
 
-  private RebarRunConfigFactory() {
+  private RebarRunConfigurationFactory() {
     super(RebarRunConfigurationType.getInstance());
   }
 
@@ -39,7 +39,7 @@ final class RebarRunConfigFactory extends ConfigurationFactory {
   }
 
   @NotNull
-  public static RebarRunConfigFactory getInstance() {
+  public static RebarRunConfigurationFactory getInstance() {
     return ourInstance;
   }
 

--- a/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationType.java
+++ b/src/org/intellij/erlang/rebar/runner/RebarRunConfigurationType.java
@@ -61,6 +61,6 @@ public final class RebarRunConfigurationType implements ConfigurationType {
   @NotNull
   @Override
   public ConfigurationFactory[] getConfigurationFactories() {
-    return new ConfigurationFactory[]{RebarRunConfigFactory.getInstance()};
+    return new ConfigurationFactory[]{RebarRunConfigurationFactory.getInstance()};
   }
 }

--- a/src/org/intellij/erlang/rebar/runner/RebarRunningState.java
+++ b/src/org/intellij/erlang/rebar/runner/RebarRunningState.java
@@ -46,16 +46,13 @@ final class RebarRunningState extends CommandLineState {
     super(env);
     myConfig = config;
     TextConsoleBuilder builder = TextConsoleBuilderFactory.getInstance().createBuilder(myConfig.getProject());
-    builder.addFilter(new RegexpFilter(config.getProject(), "$FILE_PATH$:$LINE$:\\.*") {
+    builder.addFilter(new RegexpFilter(myConfig.getProject(), "$FILE_PATH$:$LINE$:\\.*") {
       @Nullable
       @Override
       protected HyperlinkInfo createOpenFileHyperlink(String fileName, int line, int column) {
         HyperlinkInfo res = super.createOpenFileHyperlink(fileName, line, column);
         if (res == null) {
-          Project project = config.getProject();
-          RebarSettings rebarSettings = RebarSettings.getInstance(project);
-          File parentFile = new File(rebarSettings.getRebarPath()).getParentFile();
-          String absolutePath = new File(parentFile, fileName).getAbsolutePath();
+          String absolutePath = new File(myConfig.getProject().getBasePath(), fileName).getAbsolutePath();
           res = super.createOpenFileHyperlink(absolutePath, line, column);
         }
         return res;


### PR DESCRIPTION
Besides `RebarRunConfigFactory` was renamed to `RebarRunConfigurationFactory` to align with other RebarRunXXX names.
