### PR TITLE
Add Erlang specific spelling dictionary

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -209,6 +209,9 @@
         <localInspection language="Erlang" shortName="ErlangDuplicateFunction" displayName="Duplicate function"
                          groupName="Erlang" enabledByDefault="true" level="WARNING"
                          implementationClass="org.intellij.erlang.inspection.ErlangDuplicateFunctionInspection"/>
+
+        <spellchecker.bundledDictionaryProvider implementation="org.intellij.erlang.spellchecker.ErlangBundledDictionaryProvider"/>
+
         <intentionAction>
           <className>org.intellij.erlang.intention.ErlangExportFunctionIntention</className>
           <category>Erlang</category>

--- a/src/org/intellij/erlang/spellchecker/ErlangBundledDictionaryProvider.java
+++ b/src/org/intellij/erlang/spellchecker/ErlangBundledDictionaryProvider.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2013 Sergey Ignatov
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.intellij.erlang.spellchecker;
+
+import com.intellij.spellchecker.BundledDictionaryProvider;
+
+/**
+ * @author Sergey Evstifeev
+ */
+class ErlangBundledDictionaryProvider implements BundledDictionaryProvider {
+
+  @Override
+  public String[] getBundledDictionaries() {
+    return new String[]{"erlang.dic"};
+  }
+
+}

--- a/src/org/intellij/erlang/spellchecker/erlang.dic
+++ b/src/org/intellij/erlang/spellchecker/erlang.dic
@@ -1,0 +1,6 @@
+andalso
+bnot
+bxor
+cond
+orelse
+noreply


### PR DESCRIPTION
Adding some Erlang keywords to the dictionary. Keywords taken from http://www.erlang.org/doc/reference_manual/introduction.html#id60679 (only words that do not exist in the standard spellchecker dict are added).
Also added a 'noreply' word as it comes as one of the standard replies in gen_server.
