### PR TITLE
Callback specs with braces fix; Unresolved function in callback spec fix;

### DIFF
--- a/src/org/intellij/erlang/inspection/ErlangUnresolvedFunctionInspection.java
+++ b/src/org/intellij/erlang/inspection/ErlangUnresolvedFunctionInspection.java
@@ -93,6 +93,11 @@ public class ErlangUnresolvedFunctionInspection extends ErlangInspectionBase {
           problemsHolder.registerProblem(o.getQAtom(), "Unresolved function " + "'" + r.getSignature() + "'", qfs);
         }
       }
+
+      //prevents UnresolvedFunction messages in callback specifications
+      @Override
+      public void visitCallbackSpec(@NotNull ErlangCallbackSpec o) {
+      }
     });
   }
 

--- a/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
+++ b/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
@@ -1058,7 +1058,7 @@ public class ErlangPsiImplUtil {
 
   @NotNull
   public static String createFunctionPresentationFromCallbackSpec(@NotNull ErlangCallbackSpec spec) {
-    ErlangFunTypeSigs funTypeSigs = spec.getFunTypeSigs();
+    ErlangFunTypeSigs funTypeSigs = getFunTypeSigs(spec);
     String funName = getCallbackSpecName(spec);
 
     List<ErlangTypeSig> typeSigList = funTypeSigs != null ? funTypeSigs.getTypeSigList() : null;
@@ -1165,14 +1165,24 @@ public class ErlangPsiImplUtil {
 
   @Nullable
   private static ErlangQAtom getCallbackAtom(ErlangCallbackSpec spec) {
-    ErlangFunTypeSigs funTypeSigs = spec.getFunTypeSigs();
+    ErlangFunTypeSigs funTypeSigs = getFunTypeSigs(spec);
     ErlangSpecFun specFun = funTypeSigs != null ? funTypeSigs.getSpecFun() : null;
     return specFun != null ? specFun.getQAtom() : null;
   }
 
+  @Nullable
+  public static ErlangFunTypeSigs getFunTypeSigs(ErlangCallbackSpec spec) {
+    ErlangFunTypeSigs funTypeSigs = spec.getFunTypeSigs();
+    if (funTypeSigs == null) {
+      ErlangFunTypeSigsBraces braces = spec.getFunTypeSigsBraces();
+      funTypeSigs = braces != null ? braces.getFunTypeSigs() : null;
+    }
+    return funTypeSigs;
+  }
+
   @NotNull
   public static List<ErlangTopType> getCallBackSpecArguments(ErlangCallbackSpec spec) {
-    ErlangFunTypeSigs funTypeSigs = spec.getFunTypeSigs();
+    ErlangFunTypeSigs funTypeSigs = getFunTypeSigs(spec);
     List<ErlangTypeSig> typeSigList = funTypeSigs != null ? funTypeSigs.getTypeSigList() : ContainerUtil.<ErlangTypeSig>emptyList();
     ErlangTypeSig typeSig = ContainerUtil.getFirstItem(typeSigList);
     ErlangFunType funType = typeSig != null ? typeSig.getFunType() : null;

--- a/testData/highlighting/UnresolvedFunction.erl
+++ b/testData/highlighting/UnresolvedFunction.erl
@@ -1,0 +1,6 @@
+-export([bar/0]).
+
+-callback(foo(atom()) -> ok).
+
+bar() ->
+  <warning>foo</warning>().

--- a/tests/org/intellij/erlang/highlighting/ErlangHighlightingTest.java
+++ b/tests/org/intellij/erlang/highlighting/ErlangHighlightingTest.java
@@ -131,6 +131,7 @@ public class ErlangHighlightingTest extends ErlangLightPlatformCodeInsightFixtur
   public void test221()               { doTest(); }
   public void testInclude()           { doTest(); }
   public void testIncludeLib()        { doTest(); }
+  public void testUnresolvedFunction(){ doTest(); }
 
   public void testUnresolvedMacros()  {
     enableUnresolvedMacroInspection();


### PR DESCRIPTION
fixed a bug when function specification name was set to 'null' in case a callback specification with braces was used;
fixed unresolved function inspection: use of function names in callback specifications does not trigger warnings anymore;
added a highlighting test covering use of function names in callback specifications;
