### PR TITLE
RubyMine-related fixes

### DIFF
--- a/src/META-INF/java-deps.xml
+++ b/src/META-INF/java-deps.xml
@@ -16,14 +16,16 @@
 
 <idea-plugin version="2">
   <extensions defaultExtensionNs="com.intellij">
+    <moduleType id="ERLANG_MODULE" implementationClass="org.intellij.erlang.editor.ErlangModuleType"/>
     <compiler implementation="org.intellij.erlang.compilation.ErlangCompiler"/>
     <compileServer.plugin classpath="jps-plugin.jar"/>
-
-    <projectStructureDetector implementation="org.intellij.erlang.editor.ErlangProjectStructureDetector"/>
-
+    <facetType implementation="org.intellij.erlang.facet.ErlangFacetType"/>
     <localInspection language="Erlang" shortName="ErlangFacetConfigurationIssue" displayName="Facet configuration issues"
                      groupName="Erlang" enabledByDefault="true" level="WARNING"
                      implementationClass="org.intellij.erlang.inspection.ErlangFacetConfigurationIssueInspection"/>
+
+    <projectStructureDetector implementation="org.intellij.erlang.editor.ErlangProjectStructureDetector"/>
+
   </extensions>
   <project-components>
     <component>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -168,8 +168,6 @@
     </extensions>
 
     <extensions defaultExtensionNs="com.intellij">
-        <facetType implementation="org.intellij.erlang.facet.ErlangFacetType"/>
-
         <internalFileTemplate name="Erlang Module"/>
         <internalFileTemplate name="Erlang Header"/>
         <internalFileTemplate name="Erlang EUnit Tests"/>
@@ -185,8 +183,6 @@
         <liveTemplateContext implementation="org.intellij.erlang.template.ErlangContextType$Declaration"/>
         <liveTemplateContext implementation="org.intellij.erlang.template.ErlangContextType$Statement"/>
         <liveTemplateContext implementation="org.intellij.erlang.template.ErlangContextType$Expression"/>
-
-        <moduleType id="ERLANG_MODULE" implementationClass="org.intellij.erlang.editor.ErlangModuleType"/>
 
         <!-- emacs -->
         <projectService serviceImplementation="org.intellij.erlang.emacs.EmacsSettings"/>

--- a/src/org/intellij/erlang/rebar/runner/RebarEunitRerunFailedTestsAction.java
+++ b/src/org/intellij/erlang/rebar/runner/RebarEunitRerunFailedTestsAction.java
@@ -9,10 +9,14 @@ import com.intellij.execution.testframework.AbstractTestProxy;
 import com.intellij.execution.testframework.Filter;
 import com.intellij.execution.testframework.TestFrameworkRunningModel;
 import com.intellij.execution.testframework.actions.AbstractRerunFailedTestsAction;
+import com.intellij.icons.AllIcons;
 import com.intellij.notification.Notification;
 import com.intellij.notification.NotificationType;
 import com.intellij.notification.Notifications;
+import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.extensions.PluginId;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.ComponentContainer;
@@ -37,6 +41,18 @@ import java.util.Set;
  */
 @SuppressWarnings("ComponentNotRegistered")
 public class RebarEunitRerunFailedTestsAction extends AbstractRerunFailedTestsAction {
+  static {
+    // enables rerun failed tests action in RubyMine
+    final String rerunFailedTestsActionId = "RerunFailedTests";
+    ActionManager actionManager = ActionManager.getInstance();
+    AnAction rerunFailedTestsAction = actionManager.getAction(rerunFailedTestsActionId);
+    if (rerunFailedTestsAction == null) {
+      AbstractRerunFailedTestsAction action = new AbstractRerunFailedTestsAction();
+      actionManager.registerAction(rerunFailedTestsActionId, action, PluginId.getId("org.jetbrains.erlang"));
+      action.getTemplatePresentation().setIcon(AllIcons.RunConfigurations.RerunFailedTests);
+    }
+  }
+
   public RebarEunitRerunFailedTestsAction(@NotNull ComponentContainer componentContainer) {
     super(componentContainer);
   }


### PR DESCRIPTION
moved ErlangFacetType to java-deps (allows loading erlang projects without Facet-related exceptions);
added a workaround for rebar tests runner to be run in RubyMine;
