### PR TITLE
[Issue #330] Use inet:gethostname() instead of net_adm:localhost()

### DIFF
--- a/resources/debugger/src/debugnode.erl
+++ b/resources/debugger/src/debugnode.erl
@@ -12,7 +12,7 @@ main(TargetNodeName, TargetProcessName) ->
       exit(1);
     _ ->
       %%TODO check if node name contains host part
-      run({list_to_atom(TargetProcessName), list_to_atom(TargetNodeName ++ [$@|net_adm:localhost()])})
+      run({list_to_atom(TargetProcessName), list_to_atom(TargetNodeName ++ [$@|inet:gethostname()])})
   end.
 
 run(Debugger) ->


### PR DESCRIPTION
see https://github.com/ignatov/intellij-erlang/issues/330
