### PR TITLE
Templates specs

### DIFF
--- a/resources/fileTemplates/internal/Erlang Application.erl.ft
+++ b/resources/fileTemplates/internal/Erlang Application.erl.ft
@@ -25,8 +25,8 @@
 %%--------------------------------------------------------------------
 -spec(start(StartType :: normal | {takeover, node()} | {failover, node()},
         StartArgs :: term()) ->
-    {ok, Pid :: pid()} |
-    {ok, Pid :: pid(), State :: term()} |
+    {ok, pid()} |
+    {ok, pid(), State :: term()} |
     {error, Reason :: term()}).
 start(_StartType, _StartArgs) ->
     case 'TopSupervisor':start_link() of

--- a/resources/fileTemplates/internal/Erlang Gen Event.erl.ft
+++ b/resources/fileTemplates/internal/Erlang Gen Event.erl.ft
@@ -30,9 +30,7 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(start_link() ->
-    {ok, Pid :: pid()} |
-    {error, {already_started, Pid :: pid()}}).
+-spec(start_link() -> {ok, pid()} | {error, {already_started, pid()}}).
 start_link() ->
     gen_event:start_link({local, ?SERVER}).
 
@@ -58,7 +56,10 @@ add_handler() ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(init(Args :: term()) -> {ok, State :: #state{}}).
+-spec(init(InitArgs :: term()) ->
+    {ok, State :: #state{}} |
+    {ok, State :: #state{}, hibernate} |
+    {error, Reason :: term()}).
 init([]) ->
     {ok, #state{}}.
 
@@ -72,10 +73,10 @@ init([]) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(handle_event(Event :: term(), State :: #state{}) ->
-    {ok, NewState :: #stae{}} |
+    {ok, NewState :: #state{}} |
+    {ok, NewState :: #state{}, hibernate} |
     {swap_handler, Args1 :: term(), NewState :: #state{},
-        Handler2 :: atom() | {atom(), Id :: term()},
-        Args2 :: term()} |
+        Handler2 :: (atom() | {atom(), Id :: term()}), Args2 :: term()} |
     remove_handler).
 handle_event(_Event, State) ->
     {ok, State}.
@@ -91,9 +92,9 @@ handle_event(_Event, State) ->
 %%--------------------------------------------------------------------
 -spec(handle_call(Request :: term(), State :: #state{}) ->
     {ok, Reply :: term(), NewState :: #state{}} |
-    {swap_handler, Reply :: term(), Args1 :: term(),
-        NewState :: #state{},
-        Handler2 :: atom() | {atom(), Id :: term()}, Args2 :: term()} |
+    {ok, Reply :: term(), NewState :: #state{}, hibernate} |
+    {swap_handler, Reply :: term(), Args1 :: term(), NewState :: #state{},
+        Handler2 :: (atom() | {atom(), Id :: term()}), Args2 :: term()} |
     {remove_handler, Reply :: term()}).
 handle_call(_Request, State) ->
     Reply = ok,
@@ -110,9 +111,9 @@ handle_call(_Request, State) ->
 %%--------------------------------------------------------------------
 -spec(handle_info(Info :: term(), State :: #state{}) ->
     {ok, NewState :: #state{}} |
+    {ok, NewState :: #state{}, hibernate} |
     {swap_handler, Args1 :: term(), NewState :: #state{},
-        Handler2 :: atom() | {atom(), Id :: term()},
-        Args2 :: term()} |
+        Handler2 :: (atom() | {atom(), Id :: term()}), Args2 :: term()} |
     remove_handler).
 handle_info(_Info, State) ->
     {ok, State}.
@@ -127,10 +128,9 @@ handle_info(_Info, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
--spec(terminate(Arg, State :: #state{}) -> term()
-    when Arg :: term() | {stop, Reason :: term()} | stop |
+-spec(terminate(Args :: (term() | {stop, Reason :: term()} | stop |
         remove_handler | {error, {'EXIT', Reason :: term()}} |
-        {error, Reason :: term()}).
+    {error, term()}), State :: term()) -> term()).
 terminate(_Arg, _State) ->
     ok.
 

--- a/resources/fileTemplates/internal/Erlang Gen FSM.erl.ft
+++ b/resources/fileTemplates/internal/Erlang Gen FSM.erl.ft
@@ -33,8 +33,7 @@
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(start_link() ->
-    {ok, Pid :: pid()} | ignore | {error, Reason :: term()}).
+-spec(start_link() -> {ok, pid()} | ignore | {error, Reason :: term()}).
 start_link() ->
     gen_fsm:start_link({local, ?SERVER}, ?MODULE, [], []).
 
@@ -52,11 +51,9 @@ start_link() ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(init(Args :: term()) ->
-    {ok, StateName :: atom(), State :: #state{}} |
-    {ok, StateName :: atom(), State :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    ignore |
-    {stop, Reason :: term()}).
+    {ok, StateName :: atom(), StateData :: #state{}} |
+    {ok, StateName :: atom(), StateData :: #state{}, timeout() | hibernate} |
+    {stop, Reason :: term()} | ignore).
 init([]) ->
     {ok, state_name, #state{}}.
 
@@ -74,9 +71,7 @@ init([]) ->
 -spec(state_name(Event, State) ->
     {next_state, NextStateName :: atom(), NextState :: #state{}} |
     {next_state, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
+        timeout() | hibernate} |
     {stop, Reason :: term(), NewState :: #state{}}).
 state_name(_Event, State) ->
     {next_state, state_name, State}.
@@ -96,14 +91,10 @@ state_name(_Event, State) ->
         State :: #state{}) ->
     {next_state, NextStateName :: atom(), NextState :: #state{}} |
     {next_state, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
+        timeout() | hibernate} |
     {reply, Reply, NextStateName :: atom(), NextState :: #state{}} |
     {reply, Reply, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {reply, Reply, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
+        timeout() | hibernate} |
     {stop, Reason :: normal | term(), NewState :: #state{}} |
     {stop, Reason :: normal | term(), Reply :: term(),
         NewState :: #state{}}).
@@ -121,12 +112,11 @@ state_name(_Event, _From, State) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(handle_event(Event :: term(), StateName :: atom(),
-        State :: #state{}) ->
-    {next_state, NextStateName :: atom(), NextState :: #state{}} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {next_state, NextStateName :: atom(), NextState :: #state{}, hibernate} |
-    {stop, Reason :: term(), NewState :: #state{}}).
+        StateData :: #state{}) ->
+    {next_state, NextStateName :: atom(), NewStateData :: #state{}} |
+    {next_state, NextStateName :: atom(), NewStateData :: #state{},
+        timeout() | hibernate} |
+    {stop, Reason :: term(), NewStateData :: #state{}}).
 handle_event(_Event, StateName, State) ->
     {next_state, StateName, State}.
 
@@ -139,21 +129,16 @@ handle_event(_Event, StateName, State) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(handle_sync_event(Event :: term(), From :: {pid(), term()},
-        StateName :: atom(), State :: #state{}) ->
-    {next_state, NextStateName :: atom(), NextState :: #state{}} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
-    {reply, Reply, NextStateName :: atom(), NextState :: #state{}} |
-    {reply, Reply, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {reply, Reply, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
-    {stop, Reason :: normal | term(), NewState :: #state{}} |
-    {stop, Reason :: normal | term(), Reply :: term(),
-        NewState :: #state{}}).
+-spec(handle_sync_event(Event :: term(), From :: {pid(), Tag :: term()},
+        StateName :: atom(), StateData :: term()) ->
+    {reply, Reply :: term(), NextStateName :: atom(), NewStateData :: term()} |
+    {reply, Reply :: term(), NextStateName :: atom(), NewStateData :: term(),
+        timeout() | hibernate} |
+    {next_state, NextStateName :: atom(), NewStateData :: term()} |
+    {next_state, NextStateName :: atom(), NewStateData :: term(),
+        timeout() | hibernate} |
+    {stop, Reason :: term(), Reply :: term(), NewStateData :: term()} |
+    {stop, Reason :: term(), NewStateData :: term()}).
 handle_sync_event(_Event, _From, StateName, State) ->
     Reply = ok,
     {reply, Reply, StateName, State}.
@@ -168,13 +153,11 @@ handle_sync_event(_Event, _From, StateName, State) ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(handle_info(Info :: term(), StateName :: atom(),
-        State :: #state{}) ->
-    {next_state, NextStateName :: atom(), NextState :: #state{}} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {next_state, NextStateName :: atom(), NextState :: #state{},
-        hibernate} |
-    {stop, Reason :: normal | term(), NewState :: #state{}}).
+        StateData :: term()) ->
+    {next_state, NextStateName :: atom(), NewStateData :: term()} |
+    {next_state, NextStateName :: atom(), NewStateData :: term(),
+        timeout() | hibernate} |
+    {stop, Reason :: normal | term(), NewStateData :: term()}).
 handle_info(_Info, StateName, State) ->
     {next_state, StateName, State}.
 
@@ -188,8 +171,8 @@ handle_info(_Info, StateName, State) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(terminate(Reason :: term(), StateName :: atom(),
-        State :: #state{}) -> term()).
+-spec(terminate(Reason :: normal | shutdown | {shutdown, term()}
+        | term(), StateName :: atom(), StateData :: term()) -> term()).
 terminate(_Reason, _StateName, _State) ->
     ok.
 
@@ -200,9 +183,9 @@ terminate(_Reason, _StateName, _State) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(code_change(OldVsn :: term() | {down, term()},
-        StateName :: atom(), State :: #state{}, Extra :: term()) ->
-    {ok, NextStateName :: atom(), NewState :: #state{}}).
+-spec(code_change(OldVsn :: term() | {down, term()}, StateName :: atom(),
+        StateData :: #state{}, Extra :: term()) ->
+    {ok, NextStateName :: atom(), NewStateData :: #state{}}).
 code_change(_OldVsn, StateName, State, _Extra) ->
     {ok, StateName, State}.
 

--- a/resources/fileTemplates/internal/Erlang Gen Server.erl.ft
+++ b/resources/fileTemplates/internal/Erlang Gen Server.erl.ft
@@ -50,10 +50,8 @@ start_link() ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(init(Args :: term()) ->
-    {ok, State :: #state{}} |
-    {ok, State :: #state{}, Timeout :: pos_integer() | infinity} |
-    ignore |
-    {stop, Reason :: term()}).
+    {ok, State :: #state{}} | {ok, State :: #state{}, timeout() | hibernate} |
+    {stop, Reason :: term()} | ignore).
 init([]) ->
     {ok, #state{}}.
 
@@ -64,16 +62,12 @@ init([]) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(handle_call(Request :: term(), From :: {pid(), term()},
+-spec(handle_call(Request :: term(), From :: {pid(), Tag :: term()},
         State :: #state{}) ->
     {reply, Reply :: term(), NewState :: #state{}} |
-    {reply, Reply :: term(), NewState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {reply, Reply :: term(), NewState :: #state{}, hibernate} |
+    {reply, Reply :: term(), NewState :: #state{}, timeout() | hibernate} |
     {noreply, NewState :: #state{}} |
-    {noreply, NewState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {noreply, NewState :: #state{}, hibernate} |
+    {noreply, NewState :: #state{}, timeout() | hibernate} |
     {stop, Reason :: term(), Reply :: term(), NewState :: #state{}} |
     {stop, Reason :: term(), NewState :: #state{}}).
 handle_call(_Request, _From, State) ->
@@ -86,11 +80,9 @@ handle_call(_Request, _From, State) ->
 %%
 %% @end
 %%--------------------------------------------------------------------
--spec(handle_call(Request :: term(), State :: #state{}) ->
+-spec(handle_cast(Request :: term(), State :: #state{}) ->
     {noreply, NewState :: #state{}} |
-    {noreply, NewState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {noreply, NewState :: #state{}, hibernate} |
+    {noreply, NewState :: #state{}, timeout() | hibernate} |
     {stop, Reason :: term(), NewState :: #state{}}).
 handle_cast(_Request, State) ->
     {noreply, State}.
@@ -105,11 +97,9 @@ handle_cast(_Request, State) ->
 %%                                   {stop, Reason, State}
 %% @end
 %%--------------------------------------------------------------------
--spec(handle_call(Info :: term(), State :: #state{}) ->
+-spec(handle_info(Info :: timeout() | term(), State :: #state{}) ->
     {noreply, NewState :: #state{}} |
-    {noreply, NewState :: #state{},
-        Timeout :: pos_integer() | infinity} |
-    {noreply, NewState :: #state{}, hibernate} |
+    {noreply, NewState :: #state{}, timeout() | hibernate} |
     {stop, Reason :: term(), NewState :: #state{}}).
 handle_info(_Info, State) ->
     {noreply, State}.
@@ -125,7 +115,7 @@ handle_info(_Info, State) ->
 %% @spec terminate(Reason, State) -> void()
 %% @end
 %%--------------------------------------------------------------------
--spec(terminate(Reason :: normal | shutdown | {shutdown,term()} | term(),
+-spec(terminate(Reason :: (normal | shutdown | {shutdown, term()} | term()),
         State :: #state{}) -> term()).
 terminate(_Reason, _State) ->
     ok.
@@ -138,9 +128,9 @@ terminate(_Reason, _State) ->
 %% @spec code_change(OldVsn, State, Extra) -> {ok, NewState}
 %% @end
 %%--------------------------------------------------------------------
--spec(code_change(OldVsn :: term() | {down, term()},
-       State :: #state{}, Extra :: term()) ->
-    {ok, NewState :: #state{}}).
+-spec(code_change(OldVsn :: term() | {down, term()}, State :: #state{},
+        Extra :: term()) ->
+    {ok, NewState :: #state{}} | {error, Reason :: term()}).
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 

--- a/resources/fileTemplates/internal/Erlang Supervisor.erl.ft
+++ b/resources/fileTemplates/internal/Erlang Supervisor.erl.ft
@@ -42,16 +42,9 @@ start_link() ->
 %% @end
 %%--------------------------------------------------------------------
 -spec(init(Args :: term()) ->
-    {ok, {SupFlags :: {one_for_all | one_for_one |
-    rest_for_one | simple_one_for_one,
-        MaxR :: non_neg_integer(), MaxT :: pos_integer()},
-        [{Id :: term(),
-            StartFunc :: {M :: module(), F :: atom(),
-                A :: [term()] | undefined},
-            Restart :: permanent | transient | temporary,
-            Shutdown :: brutal_kill | Timeout :: pos_integer(),
-            Type :: worker | supervisor,
-            [module()] | dynamic}]
+    {ok, {SupFlags :: {RestartStrategy :: supervisor:strategy(),
+        MaxR :: non_neg_integer(), MaxT :: non_neg_integer()},
+        [ChildSpec :: supervisor:child_spec()]
     }} |
     ignore |
     {error, Reason :: term()}).


### PR DESCRIPTION
dyalizer friendly spec 

some @spec were incomplete, outdated and

http://www.erlang.org/doc/apps/edoc/chapter.html#Type_specifications
Although the syntax described in the following can still be used for specifying functions we recommend that Erlang specifications as described in Types and Function Specification should be added to the source code instead. This way the analyses of Dialyzer's can be utilized in the process of keeping the documentation consistent and up-to-date. 
