### PR TITLE
Fix function spec find bug.

### DIFF
--- a/testData/quickfixes/export/deleteSpec2-after.erl
+++ b/testData/quickfixes/export/deleteSpec2-after.erl
@@ -1,0 +1,11 @@
+%%  Copyright (c) 2012. Sergey Ignatov.
+-module(empty).
+-author("ignatov").
+
+%% API
+-export([bar/10, zoo/2]).
+
+-spec bar() -> atom().
+bar() -> ok.
+
+<caret>

--- a/testData/quickfixes/export/deleteSpec2.erl
+++ b/testData/quickfixes/export/deleteSpec2.erl
@@ -1,0 +1,13 @@
+%%  Copyright (c) 2012. Sergey Ignatov.
+-module(empty).
+-author("ignatov").
+
+%% API
+-export([bar/10, zoo/2]).
+
+-spec(foo() ->  ok).
+
+-spec bar() -> atom().
+bar() -> ok.
+
+foo<caret>() -> ok.

--- a/testData/quickfixes/export/deleteSpec3-after.erl
+++ b/testData/quickfixes/export/deleteSpec3-after.erl
@@ -1,0 +1,7 @@
+%%  Copyright (c) 2012. Sergey Ignatov.
+-module(empty).
+-author("ignatov").
+
+bar() -> ok.
+
+-spec bar() -> atom().

--- a/testData/quickfixes/export/deleteSpec3.erl
+++ b/testData/quickfixes/export/deleteSpec3.erl
@@ -1,0 +1,9 @@
+%%  Copyright (c) 2012. Sergey Ignatov.
+-module(empty).
+-author("ignatov").
+
+bar() -> ok.
+foo<caret>() -> ok.
+
+-spec bar() -> atom().
+-spec foo() -> atom().

--- a/tests/org/intellij/erlang/quickfixes/ErlangFunctionFixesTest.java
+++ b/tests/org/intellij/erlang/quickfixes/ErlangFunctionFixesTest.java
@@ -45,8 +45,11 @@ public class ErlangFunctionFixesTest extends ErlangQuickFixTestBase {
   public void testEmpty()      { doTest("Export function"); }
   public void testWithout()    { doTest("Export function"); }
   public void testCommon()     { doTest("Export function"); }
+
   public void testDelete()     { doTest("Remove function"); }
   public void testDeleteSpec() { doTest("Remove function"); }
+  public void testDeleteSpec2() { doTest("Remove function"); }
+  public void testDeleteSpec3() { doTest("Remove function"); }
 
   public void testOneDuplicateExport1() { doTest("Remove duplicate export"); }
   public void testOneDuplicateExport2() { doTest("Remove duplicate export"); }


### PR DESCRIPTION
It is okay to write smth like:

``` erlang
-spec foo() -> atom().
%% other stuff
spec bar() -> atom().
bar() -> ok.
%% other stuff
foo() -> ok.
```

in terms of Erlang interpreter, i.e. specify spec not right before function definition.
But in this case ErlangPsiImplUtil#getSpecification doesn't see spec for foo (as you can see while "Remove function" intention).
This is fixed now.
