### PR TITLE
When debugging a remote node, allows setting the host part of the local ...

### DIFF
--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
@@ -31,6 +31,7 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
   private String myRemoteErlangNodeName;
   private boolean myUseShortNames = true; // controls whether to use -name or -sname for specifying local node name
   private String myCookie;
+  private String myLongNameHost;
 
   public ErlangRemoteDebugRunConfiguration(Project project, String name) {
     super(name, new ErlangModuleBasedConfiguration(project), ErlangRemoteDebugRunConfigurationType.getInstance().getConfigurationFactories()[0]);
@@ -75,4 +76,13 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
   public void setCookie(String cookie) {
     myCookie = cookie;
   }
+
+  public String getLongNameHost() {
+    return myLongNameHost;
+  }
+
+  public void setLongNameHost(String longNameHost) {
+    myLongNameHost = longNameHost;
+  }
+
 }

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
@@ -26,7 +26,9 @@ import com.intellij.openapi.module.Module;
 import com.intellij.util.containers.ContainerUtil;
 import org.intellij.erlang.runconfig.ErlangRunningState;
 import org.jetbrains.annotations.NotNull;
+import java.net.InetAddress;
 
+import java.net.UnknownHostException;
 import java.util.List;
 
 public class ErlangRemoteDebugRunningState extends ErlangRunningState {
@@ -66,8 +68,30 @@ public class ErlangRemoteDebugRunningState extends ErlangRunningState {
 
   @Override
   protected List<String> getErlFlags() {
-    String nodeNameFlag = myConfiguration.isUseShortNames() ? "-sname" : "-name";
+    String nodeNameFlag;
     String nodeName = "debugger_node_" + System.currentTimeMillis();
+
+    if (myConfiguration.isUseShortNames()) {
+      nodeNameFlag = "-sname";
+    }
+    else {
+      nodeNameFlag = "-name";
+
+      //Find the host part of the name
+      String longNameHost = myConfiguration.getLongNameHost();
+      if (longNameHost==null || longNameHost.equals("")) {
+        try {
+          InetAddress addr = InetAddress.getLocalHost();
+          longNameHost = addr.getCanonicalHostName();
+        }
+        catch(UnknownHostException e) {
+          longNameHost = "127.0.0.1";
+        }
+      }
+
+      nodeName = nodeName + "@" + longNameHost;
+    }
+
     return ContainerUtil.list(nodeNameFlag, nodeName);
   }
 }

--- a/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
+++ b/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.intellij.erlang.debugger.remote.ui.ErlangRemoteDebugConfigurationEditorForm">
-  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -18,7 +18,7 @@
       </component>
       <vspacer id="4a98e">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="8101c" class="javax.swing.JLabel">
@@ -75,9 +75,27 @@
       </component>
       <component id="f984b" class="com.intellij.ui.HideableTitledPanel" binding="myDebugOptionsPanel" custom-create="true" default-binding="true">
         <constraints>
-          <grid row="4" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+      </component>
+      <component id="47150" class="javax.swing.JTextField" binding="myLongNameHostTextField">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="cb618" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="47150"/>
+          <text value="&amp;Long name host:"/>
+          <toolTipText value="The host part of the long name. Defaults to the system hostname"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.java
+++ b/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.java
@@ -25,6 +25,8 @@ import org.intellij.erlang.runconfig.ui.ErlangDebuggableRunConfigurationEditor;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
+import java.awt.event.ItemEvent;
+import java.awt.event.ItemListener;
 
 public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRunConfigurationEditor<ErlangRemoteDebugRunConfiguration> {
   private JPanel myComponent;
@@ -33,6 +35,16 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
   private JTextField myCookieTextField;
   private JCheckBox myUseShortNamesCheckBox;
   private HideableTitledPanel myDebugOptionsPanel;
+  private JTextField myLongNameHostTextField;
+
+  public ErlangRemoteDebugConfigurationEditorForm() {
+    myUseShortNamesCheckBox.addItemListener(new ItemListener() {
+      @Override
+      public void itemStateChanged(ItemEvent e) {
+        myLongNameHostTextField.setEnabled(!myUseShortNamesCheckBox.isSelected());
+      }
+    });
+  }
 
   @Override
   protected void doResetEditorFrom(ErlangRemoteDebugRunConfiguration configuration) {
@@ -41,6 +53,8 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
     myNodeTextField.setText(configuration.getRemoteErlangNodeName());
     myCookieTextField.setText(configuration.getCookie());
     myUseShortNamesCheckBox.setSelected(configuration.isUseShortNames());
+    myLongNameHostTextField.setEnabled(!myUseShortNamesCheckBox.isSelected());
+    myLongNameHostTextField.setText(configuration.getLongNameHost());
   }
 
   @Override
@@ -49,6 +63,7 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
     configuration.setRemoteErlangNodeName(myNodeTextField.getText());
     configuration.setCookie(myCookieTextField.getText());
     configuration.setUseShortNames(myUseShortNamesCheckBox.isSelected());
+    configuration.setLongNameHost(myLongNameHostTextField.getText());
   }
 
   @NotNull


### PR DESCRIPTION
...long name node, and defaults it to the system hostname.

fixes #561.