### PR TITLE
fix myAddDebugInfoCheckBox configuration bug

### DIFF
--- a/jps-shared/src/org/intellij/erlang/jps/model/ErlangCompilerOptions.java
+++ b/jps-shared/src/org/intellij/erlang/jps/model/ErlangCompilerOptions.java
@@ -24,6 +24,7 @@ public class ErlangCompilerOptions {
 
   public ErlangCompilerOptions(ErlangCompilerOptions options) {
     myUseRebarCompiler = options.myUseRebarCompiler;
+    myAddDebugInfoEnabled = options.myAddDebugInfoEnabled;
   }
 
   @Tag("useRebarCompiler")

--- a/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.java
+++ b/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.java
@@ -100,6 +100,12 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
 
   @Override
   public boolean isModified() {
-    return myUseRebarCompilerCheckBox.isSelected() != mySettings.isUseRebarCompilerEnabled();
+    if(myUseRebarCompilerCheckBox.isSelected() != mySettings.isUseRebarCompilerEnabled()) {
+      return true;
+    }
+    if(myAddDebugInfoCheckBox.isSelected() != mySettings.isAddDebugInfoEnabled()) {
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
It was not possible to turn off debug info in compiler settings