### PR TITLE
Added option for own debug node commandline arguments to Remote Debugger

### DIFF
--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
@@ -86,8 +86,12 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
     myHost = host;
   }
 
-  public String getDebugNodeArgs() {return myDebugNodeArgs; }
+  public String getDebugNodeArgs() {
+    return myDebugNodeArgs;
+  }
 
-  public void setDebugNodeArgs(String debugNodeArgs) {myDebugNodeArgs = debugNodeArgs; }
+  public void setDebugNodeArgs(String debugNodeArgs) {
+    myDebugNodeArgs = debugNodeArgs;
+  }
 
 }

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
@@ -32,6 +32,7 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
   private boolean myUseShortNames = true; // controls whether to use -name or -sname for specifying local node name
   private String myCookie;
   private String myHost;
+  private String myDebugNodeArgs;
 
   public ErlangRemoteDebugRunConfiguration(Project project, String name) {
     super(name, new ErlangModuleBasedConfiguration(project), ErlangRemoteDebugRunConfigurationType.getInstance().getConfigurationFactories()[0]);
@@ -84,5 +85,9 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
   public void setHost(String host) {
     myHost = host;
   }
+
+  public String getDebugNodeArgs() {return myDebugNodeArgs; }
+
+  public void setDebugNodeArgs(String debugNodeArgs) {myDebugNodeArgs = debugNodeArgs; }
 
 }

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
@@ -31,6 +31,8 @@ import org.jetbrains.annotations.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class ErlangRemoteDebugRunningState extends ErlangRunningState {
@@ -76,13 +78,21 @@ public class ErlangRemoteDebugRunningState extends ErlangRunningState {
 
   @Override
   protected List<String> getErlFlags() {
+    List<String> result;
+
+
     if (myConfiguration.isUseShortNames()) {
-      return ContainerUtil.list("-sname", getNodeName());
+      result = new ArrayList<String>(ContainerUtil.list("-sname", getNodeName()));
+
+    } else {
+      String host = StringUtil.nullize(myConfiguration.getHost(), true);
+      String qualifiedName = getNodeName() + "@" + (host == null ? getDefaultHost() : host);
+      result = new ArrayList<String>(ContainerUtil.list("-name", qualifiedName));
     }
 
-    String host = StringUtil.nullize(myConfiguration.getHost(), true);
-    String qualifiedName = getNodeName() + "@" + (host == null ? getDefaultHost() : host);
-    return ContainerUtil.list("-name", qualifiedName);
+    List<String> debugNodeArgs = Arrays.asList(myConfiguration.getDebugNodeArgs().split(" "));
+    result.addAll(debugNodeArgs);
+    return result;
   }
 
   @NotNull

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
@@ -25,14 +25,13 @@ import com.intellij.execution.ui.ConsoleView;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.util.containers.ContainerUtil;
+import com.intellij.util.execution.ParametersListUtil;
 import org.intellij.erlang.runconfig.ErlangRunningState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 public class ErlangRemoteDebugRunningState extends ErlangRunningState {
@@ -78,21 +77,17 @@ public class ErlangRemoteDebugRunningState extends ErlangRunningState {
 
   @Override
   protected List<String> getErlFlags() {
-    List<String> result;
-
 
     if (myConfiguration.isUseShortNames()) {
-      result = new ArrayList<String>(ContainerUtil.list("-sname", getNodeName()));
+      return ContainerUtil.concat(ContainerUtil.list("-sname", getNodeName()),
+                                  ParametersListUtil.parse(myConfiguration.getDebugNodeArgs()));
 
-    } else {
-      String host = StringUtil.nullize(myConfiguration.getHost(), true);
-      String qualifiedName = getNodeName() + "@" + (host == null ? getDefaultHost() : host);
-      result = new ArrayList<String>(ContainerUtil.list("-name", qualifiedName));
     }
 
-    List<String> debugNodeArgs = Arrays.asList(myConfiguration.getDebugNodeArgs().split(" "));
-    result.addAll(debugNodeArgs);
-    return result;
+    String host = StringUtil.nullize(myConfiguration.getHost(), true);
+    String qualifiedName = getNodeName() + "@" + (host == null ? getDefaultHost() : host);
+    return ContainerUtil.concat(ContainerUtil.list("-name", qualifiedName),
+                                ParametersListUtil.parse(myConfiguration.getDebugNodeArgs()));
   }
 
   @NotNull

--- a/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
+++ b/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
@@ -104,7 +104,7 @@
         </constraints>
         <properties>
           <labelFor value="765c"/>
-          <text value="Debugger node &amp;args:"/>
+          <text value="&amp;Debugger node args:"/>
           <toolTipText value="Additional arguments to pass to the local debugger node"/>
         </properties>
       </component>

--- a/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
+++ b/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.intellij.erlang.debugger.remote.ui.ErlangRemoteDebugConfigurationEditorForm">
-  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="7" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myComponent" layout-manager="GridLayoutManager" row-count="8" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -19,7 +19,7 @@
       </component>
       <vspacer id="4a98e">
         <constraints>
-          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="7" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="8101c" class="javax.swing.JLabel">
@@ -70,7 +70,7 @@
       </component>
       <component id="f984b" class="com.intellij.ui.HideableTitledPanel" binding="myDebugOptionsPanel" custom-create="true" default-binding="true">
         <constraints>
-          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="6" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
       </component>
@@ -95,6 +95,24 @@
       <component id="c1235" class="com.intellij.application.options.ModulesComboBox" binding="myModuleComboBox">
         <constraints>
           <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="cab9d" class="javax.swing.JLabel">
+        <constraints>
+          <grid row="5" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <labelFor value="765c"/>
+          <text value="Debugger node &amp;args:"/>
+          <toolTipText value="Additional arguments to pass to the local debugger node"/>
+        </properties>
+      </component>
+      <component id="765c" class="javax.swing.JTextField" binding="myDebugNodeArgsTextField">
+        <constraints>
+          <grid row="5" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+            <preferred-size width="150" height="-1"/>
+          </grid>
         </constraints>
         <properties/>
       </component>

--- a/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.java
+++ b/src/org/intellij/erlang/debugger/remote/ui/ErlangRemoteDebugConfigurationEditorForm.java
@@ -37,6 +37,7 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
   private HideableTitledPanel myDebugOptionsPanel;
   private JTextField myHostTextField;
   private JLabel myHostLabel;
+  private JTextField myDebugNodeArgsTextField;
 
   public ErlangRemoteDebugConfigurationEditorForm() {
     myUseShortNamesCheckBox.addItemListener(new ItemListener() {
@@ -55,6 +56,7 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
     myCookieTextField.setText(configuration.getCookie());
     myUseShortNamesCheckBox.setSelected(configuration.isUseShortNames());
     myHostTextField.setText(configuration.getHost());
+    myDebugNodeArgsTextField.setText(configuration.getDebugNodeArgs());
     setUseShortNames(myUseShortNamesCheckBox.isSelected());
   }
 
@@ -65,6 +67,7 @@ public class ErlangRemoteDebugConfigurationEditorForm extends ErlangDebuggableRu
     configuration.setCookie(myCookieTextField.getText());
     configuration.setUseShortNames(myUseShortNamesCheckBox.isSelected());
     configuration.setHost(myHostTextField.getText());
+    configuration.setDebugNodeArgs(myDebugNodeArgsTextField.getText());
   }
 
   @NotNull


### PR DESCRIPTION
Added an option that allows the user to specify further commandline arguments when using the remote debug feature. That can be useful for example if the user want's to include other binary folders using the '-pa xyz' argument.