### PR TITLE
Minor rebar and eunit integration improvements

### DIFF
--- a/jps-plugin/src/org/intellij/erlang/jps/model/ErlangCompilerOptions.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/model/ErlangCompilerOptions.java
@@ -29,6 +29,7 @@ public class ErlangCompilerOptions {
   public ErlangCompilerOptions(ErlangCompilerOptions options) {
     myUseRebarCompiler = options.myUseRebarCompiler;
     myAddDebugInfoEnabled = options.myAddDebugInfoEnabled;
+    myCustomRebarConfig = options.myCustomRebarConfig;
   }
 
   @Tag("useRebarCompiler")
@@ -36,6 +37,12 @@ public class ErlangCompilerOptions {
 
   @Tag("useDebugInfo")
   public boolean myAddDebugInfoEnabled = true;
+
+  @Tag("customRebarConfig")
+  public String myCustomRebarConfig = "";
+
+  @Tag("customEunitRebarConfig")
+  public String myCustomEunitRebarConfig = "";
 
   @Tag("additionalErlcArguments")
   @AbstractCollection(elementTag = "arg", elementTypes = String.class)

--- a/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
@@ -62,7 +62,7 @@ public class RebarBuilder extends TargetBuilder<ErlangSourceRootDescriptor, Erla
                     @NotNull DirtyFilesHolder<ErlangSourceRootDescriptor, ErlangTarget> holder,
                     @NotNull BuildOutputConsumer outputConsumer,
                     @NotNull CompileContext context) throws ProjectBuildException, IOException {
-    if (!holder.hasDirtyFiles() && !holder.hasRemovedFiles()) return;
+    // Do not check for dirty files, delegate it to rebar
 
     JpsModule module = target.getModule();
     JpsProject project = module.getProject();

--- a/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
@@ -80,14 +80,15 @@ public class RebarBuilder extends TargetBuilder<ErlangSourceRootDescriptor, Erla
     String escriptPath = JpsErlangSdkType.getScriptInterpreterExecutable(sdk.getHomePath()).getAbsolutePath();
     String customRebarConfig = StringUtil.isEmptyOrSpaces(compilerOptions.myCustomRebarConfig) ? null : compilerOptions.myCustomRebarConfig;
     String customEunitRebarConfig = StringUtil.isEmptyOrSpaces(compilerOptions.myCustomEunitRebarConfig) ? customRebarConfig : compilerOptions.myCustomEunitRebarConfig;
+    boolean isForcedBuild = context.getScope().isBuildForced(target);
     boolean isRebarRun = false;
     for (String contentRootUrl : module.getContentRootsList().getUrls()) {
       String contentRootPath = getPathFromURL(contentRootUrl);
       if (customRebarConfig == null) {
         if (!isRebarConfigExists(contentRootPath, REBAR_CONFIG_FILE_NAME)) continue;
       }
-      runRebar(escriptPath, rebarPath, contentRootPath, customRebarConfig, false, compilerOptions.myAddDebugInfoEnabled, context);
-      runRebar(escriptPath, rebarPath, contentRootPath, customEunitRebarConfig, true, true, context);
+      runRebar(escriptPath, rebarPath, contentRootPath, customRebarConfig, false, compilerOptions.myAddDebugInfoEnabled, isForcedBuild, context);
+      runRebar(escriptPath, rebarPath, contentRootPath, customEunitRebarConfig, true, true, isForcedBuild, context);
       isRebarRun = true;
     }
     if (!isRebarRun) {
@@ -108,11 +109,16 @@ public class RebarBuilder extends TargetBuilder<ErlangSourceRootDescriptor, Erla
                                @Nullable String customRebarConfig,
                                boolean isTest,
                                boolean addDebugInfo,
+                               boolean isForcedBuild,
                                @NotNull CompileContext context) throws ProjectBuildException {
     GeneralCommandLine commandLine = new GeneralCommandLine();
     commandLine.withWorkDirectory(contentRootPath);
     commandLine.setExePath(escriptPath);
     commandLine.addParameter(rebarPath);
+
+    if (isForcedBuild) {
+      commandLine.addParameter("clean");
+    }
 
     if (isTest) {
       commandLine.addParameter("eunit");

--- a/src/org/intellij/erlang/application/ErlangApplicationConfiguration.java
+++ b/src/org/intellij/erlang/application/ErlangApplicationConfiguration.java
@@ -64,6 +64,11 @@ public class ErlangApplicationConfiguration extends ErlangRunConfigurationBase<E
     return myUseTestCodePath;
   }
 
+  @Override
+  public boolean isUseRebarPaths() {
+    return false;
+  }
+
   public void setUseTestCodePath(boolean useTestCodePath) {
     myUseTestCodePath = useTestCodePath;
   }

--- a/src/org/intellij/erlang/application/ErlangApplicationRunningState.java
+++ b/src/org/intellij/erlang/application/ErlangApplicationRunningState.java
@@ -44,6 +44,11 @@ public class ErlangApplicationRunningState extends ErlangRunningState {
   }
 
   @Override
+  protected boolean useRebarOutputPaths() {
+    return false;
+  }
+
+  @Override
   protected boolean isNoShellMode() {
     return true;
   }

--- a/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.form
+++ b/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.intellij.erlang.configuration.ErlangCompilerOptionsConfigurable">
-  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myRootPanel" layout-manager="GridLayoutManager" row-count="6" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -23,7 +23,7 @@
       </component>
       <vspacer id="41a3d">
         <constraints>
-          <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="5" column="0" row-span="1" col-span="2" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="c5f5e" class="javax.swing.JButton" binding="myConfigureRebarButton">
@@ -56,6 +56,34 @@
           <labelFor value="2a623"/>
           <text value="Additional 'erlc' ar&amp;guments:"/>
         </properties>
+      </component>
+      <component id="85a7e" class="javax.swing.JLabel" binding="myCustomRebarConfigLabel">
+        <constraints>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Custom rebar.config:"/>
+        </properties>
+      </component>
+      <component id="13a8" class="com.intellij.ui.RawCommandLineEditor" binding="myCustomRebarConfigEditor">
+        <constraints>
+          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+      </component>
+      <component id="81959" class="javax.swing.JLabel" binding="myCustomEunitRebarConfigLabel">
+        <constraints>
+          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Custom rebar.config for EUnit:"/>
+        </properties>
+      </component>
+      <component id="d43f1" class="com.intellij.ui.RawCommandLineEditor" binding="myCustomEunitRebarConfigEditor">
+        <constraints>
+          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="3" hsize-policy="7" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.java
+++ b/src/org/intellij/erlang/configuration/ErlangCompilerOptionsConfigurable.java
@@ -44,7 +44,11 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
   private JCheckBox myAddDebugInfoCheckBox;
   private RawCommandLineEditor myAdditionalErlcArgumentsEditor;
   private JLabel myAdditionalErlcArgumentsLabel;
-  private final ErlangCompilerSettings mySettings;
+  private JLabel myCustomRebarConfigLabel;
+  private RawCommandLineEditor myCustomRebarConfigEditor;
+    private RawCommandLineEditor myCustomEunitRebarConfigEditor;
+    private JLabel myCustomEunitRebarConfigLabel;
+    private final ErlangCompilerSettings mySettings;
   private final Project myProject;
 
   public ErlangCompilerOptionsConfigurable(Project project) {
@@ -95,6 +99,8 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
     myConfigureRebarButton.setVisible(!rebarPathIsSet);
     setUseRebarCompiler(rebarPathIsSet && mySettings.isUseRebarCompilerEnabled());
     myAddDebugInfoCheckBox.setSelected(mySettings.isAddDebugInfoEnabled());
+    myCustomRebarConfigEditor.setText(mySettings.getCustomRebarConfig());
+    myCustomEunitRebarConfigEditor.setText(mySettings.getCustomEunitRebarConfig());
     myAdditionalErlcArgumentsEditor.setText(argumentsString(mySettings.getAdditionalErlcArguments()));
   }
 
@@ -102,6 +108,8 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
   public void apply() throws ConfigurationException {
     mySettings.setUseRebarCompilerEnabled(myUseRebarCompilerCheckBox.isSelected());
     mySettings.setAddDebugInfoEnabled(myAddDebugInfoCheckBox.isSelected());
+    mySettings.setCustomRebarConfig(myCustomRebarConfigEditor.getText());
+    mySettings.setCustomEunitRebarConfig(myCustomEunitRebarConfigEditor.getText());
     mySettings.setAdditionalErlcArguments(arguments(myAdditionalErlcArgumentsEditor.getText()));
   }
 
@@ -109,6 +117,8 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
   public boolean isModified() {
     return myUseRebarCompilerCheckBox.isSelected() != mySettings.isUseRebarCompilerEnabled() ||
            myAddDebugInfoCheckBox.isSelected() != mySettings.isAddDebugInfoEnabled() ||
+           !StringUtil.equals(myCustomRebarConfigEditor.getText(), mySettings.getCustomRebarConfig()) ||
+           !StringUtil.equals(myCustomEunitRebarConfigEditor.getText(), mySettings.getCustomEunitRebarConfig()) ||
            !StringUtil.equals(myAdditionalErlcArgumentsEditor.getText(),
                               argumentsString(mySettings.getAdditionalErlcArguments()));
   }
@@ -116,6 +126,10 @@ public class ErlangCompilerOptionsConfigurable extends CompilerConfigurable {
   private void setUseRebarCompiler(boolean useRebarCompiler) {
     myUseRebarCompilerCheckBox.setSelected(useRebarCompiler);
 
+    myCustomRebarConfigLabel.setVisible(useRebarCompiler);
+    myCustomRebarConfigEditor.setVisible(useRebarCompiler);
+    myCustomEunitRebarConfigLabel.setVisible(useRebarCompiler);
+    myCustomEunitRebarConfigEditor.setVisible(useRebarCompiler);
     myAdditionalErlcArgumentsLabel.setVisible(!useRebarCompiler);
     myAdditionalErlcArgumentsEditor.setVisible(!useRebarCompiler);
   }

--- a/src/org/intellij/erlang/configuration/ErlangCompilerSettings.java
+++ b/src/org/intellij/erlang/configuration/ErlangCompilerSettings.java
@@ -55,6 +55,24 @@ public class ErlangCompilerSettings implements PersistentStateComponent<ErlangCo
     myCompilerOptions.myUseRebarCompiler = useRebarCompiler;
   }
 
+  @NotNull
+  public String getCustomRebarConfig() {
+    return myCompilerOptions.myCustomRebarConfig;
+  }
+
+  public void setCustomRebarConfig(@NotNull String customRebarConfig) {
+    myCompilerOptions.myCustomRebarConfig = customRebarConfig;
+  }
+
+  @NotNull
+  public String getCustomEunitRebarConfig() {
+    return myCompilerOptions.myCustomEunitRebarConfig;
+  }
+
+  public void setCustomEunitRebarConfig(@NotNull String customEunitRebarConfig) {
+    myCompilerOptions.myCustomEunitRebarConfig = customEunitRebarConfig;
+  }
+
   public boolean isAddDebugInfoEnabled() {
     return myCompilerOptions.myAddDebugInfoEnabled;
   }

--- a/src/org/intellij/erlang/console/ErlangConsoleCommandLineState.java
+++ b/src/org/intellij/erlang/console/ErlangConsoleCommandLineState.java
@@ -58,7 +58,7 @@ public class ErlangConsoleCommandLineState extends CommandLineState {
     commandLine.setExePath(ErlangConsoleUtil.getErlPath(project, module));
     String consoleArgs = myConfig.getConsoleArgs();
     commandLine.addParameters(StringUtil.split(consoleArgs, " "));
-    commandLine.addParameters(ErlangConsoleUtil.getCodePath(project, module, false));
+    commandLine.addParameters(ErlangConsoleUtil.getCodePath(project, module, false, false));
     commandLine.setWorkDirectory(ErlangConsoleUtil.getWorkingDirPath(project, myConfig.getWorkingDirPath()));
     OSProcessHandler handler = new OSProcessHandler(commandLine.createProcess(), commandLine.getCommandLineString());
     ProcessTerminatedListener.attach(handler);

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunConfiguration.java
@@ -44,6 +44,11 @@ public class ErlangRemoteDebugRunConfiguration extends ErlangRunConfigurationBas
   }
 
   @Override
+  public boolean isUseRebarPaths() {
+    return false;
+  }
+
+  @Override
   protected ErlangRemoteDebugRunningState newRunningState(ExecutionEnvironment env, Module module) {
     return new ErlangRemoteDebugRunningState(env, module, this);
   }

--- a/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
+++ b/src/org/intellij/erlang/debugger/remote/ErlangRemoteDebugRunningState.java
@@ -48,6 +48,11 @@ public class ErlangRemoteDebugRunningState extends ErlangRunningState {
   }
 
   @Override
+  protected boolean useRebarOutputPaths() {
+    return false;
+  }
+
+  @Override
   protected boolean isNoShellMode() {
     return true;
   }

--- a/src/org/intellij/erlang/debugger/xdebug/ErlangXDebugProcess.java
+++ b/src/org/intellij/erlang/debugger/xdebug/ErlangXDebugProcess.java
@@ -29,6 +29,7 @@ import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileTypes.FileType;
 import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.util.io.FileUtil;
@@ -63,10 +64,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.net.URL;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static org.intellij.erlang.debugger.ErlangDebuggerLog.LOG;
@@ -182,15 +180,52 @@ public class ErlangXDebugProcess extends XDebugProcess implements ErlangDebugger
 
   private void setModulesToInterpret() {
     Project project = myExecutionEnvironment.getProject();
-    Collection<ErlangFile> erlangModules = ErlangModulesUtil.getErlangModules(project);
     ErlangRunConfigurationBase<?> runConfiguration = getRunConfiguration();
+
+    Collection<ErlangFile> erlangModules;
+    switch (runConfiguration.getDebugOptions().getInterpretModulesLevel()) {
+      case PROJECT:
+        erlangModules = ErlangModulesUtil.getErlangModules(project);
+        break;
+      case DEPENDENCIES:
+        erlangModules = new ArrayList<>();
+        Module currentModule = runConfiguration.getConfigurationModule().getModule();
+        if (currentModule != null) {
+          erlangModules.addAll(ErlangModulesUtil.getErlangModules(currentModule, false));
+          ModuleManager moduleManager = ModuleManager.getInstance(project);
+          for (Module module : moduleManager.getModules()) {
+            if (moduleManager.isModuleDependent(currentModule, module)) {
+              erlangModules.addAll(ErlangModulesUtil.getErlangModules(module, false));
+            }
+          }
+        }
+        break;
+      case MODULE:
+        Module module = runConfiguration.getConfigurationModule().getModule();
+        if (module != null) {
+          erlangModules = ErlangModulesUtil.getErlangModules(module, false);
+        } else {
+          erlangModules = new ArrayList<>();
+        }
+        break;
+      default:
+        erlangModules = new ArrayList<>();
+    }
+
     if (runConfiguration.isUseTestCodePath()) {
-      HashSet<ErlangFile> erlangTestModules = new HashSet<>();
-      for (Module module : runConfiguration.getModules()) {
-        erlangTestModules.addAll(ErlangModulesUtil.getErlangModules(module, true));
+      if (runConfiguration.isUseRebarPaths()) {
+        Module module = runConfiguration.getConfigurationModule().getModule();
+        if (module != null) {
+          erlangModules.addAll(ErlangModulesUtil.getErlangModules(module, true));
+        }
+      } else {
+        HashSet<ErlangFile> erlangTestModules = new HashSet<>();
+        for (Module module : runConfiguration.getModules()) {
+          erlangTestModules.addAll(ErlangModulesUtil.getErlangModules(module, true));
+        }
+        erlangTestModules.addAll(erlangModules);
+        erlangModules = erlangTestModules;
       }
-      erlangTestModules.addAll(erlangModules);
-      erlangModules = erlangTestModules;
     }
     Set<String> notToInterpret = runConfiguration.getDebugOptions().getModulesNotToInterpret();
     List<String> moduleSourcePaths = ContainerUtil.newArrayListWithCapacity(erlangModules.size());

--- a/src/org/intellij/erlang/eunit/ErlangUnitRunConfiguration.java
+++ b/src/org/intellij/erlang/eunit/ErlangUnitRunConfiguration.java
@@ -57,6 +57,11 @@ public class ErlangUnitRunConfiguration extends ErlangRunConfigurationBase<Erlan
     return true;
   }
 
+  @Override
+  public boolean isUseRebarPaths() {
+    return myConfigData.isUseRebarPaths();
+  }
+
   @NotNull
   public ErlangUnitConfigData getConfigData() {
     return myConfigData;
@@ -88,6 +93,8 @@ public class ErlangUnitRunConfiguration extends ErlangRunConfigurationBase<Erlan
     @NotNull
     private Set<String> myFunctionNames = new LinkedHashSet<>();
 
+    private boolean myUseRebarPaths;
+
     @NotNull
     public ErlangUnitRunConfigurationKind getKind() {
       return myKind;
@@ -113,6 +120,14 @@ public class ErlangUnitRunConfiguration extends ErlangRunConfigurationBase<Erlan
 
     public void setFunctionNames(@NotNull Set<String> functionNames) {
       myFunctionNames = functionNames;
+    }
+
+    public boolean isUseRebarPaths() {
+      return myUseRebarPaths;
+    }
+
+    public void setUseRebarPaths(boolean useRebarPaths) {
+      myUseRebarPaths = useRebarPaths;
     }
   }
 }

--- a/src/org/intellij/erlang/eunit/ErlangUnitRunningState.java
+++ b/src/org/intellij/erlang/eunit/ErlangUnitRunningState.java
@@ -69,6 +69,11 @@ public class ErlangUnitRunningState extends ErlangRunningState {
   }
 
   @Override
+  protected boolean useRebarOutputPaths() {
+    return myConfiguration.getConfigData().isUseRebarPaths();
+  }
+
+  @Override
   protected boolean isNoShellMode() {
     return true;
   }

--- a/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.form
+++ b/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.form
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.intellij.erlang.eunit.ui.ErlangUnitRunConfigurationEditorForm">
-  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="657" height="207"/>
+      <xy x="20" y="20" width="657" height="226"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -103,14 +103,22 @@
       </grid>
       <vspacer id="632bf">
         <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
+          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
       <component id="7bc4a" class="com.intellij.ui.HideableTitledPanel" binding="myDebugOptionsHideablePanel" custom-create="true">
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
+      </component>
+      <component id="b6d29" class="javax.swing.JCheckBox" binding="myUseRebarOutputPathsCheckbox">
+        <constraints>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties>
+          <text value="Use rebar binaries paths (ebin, .eunit) instead of project compiler output"/>
+        </properties>
       </component>
     </children>
   </grid>

--- a/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.form
+++ b/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.form
@@ -3,7 +3,7 @@
   <grid id="27dc6" binding="component" layout-manager="GridLayoutManager" row-count="4" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
-      <xy x="20" y="20" width="657" height="226"/>
+      <xy x="20" y="20" width="657" height="246"/>
     </constraints>
     <properties/>
     <border type="none"/>
@@ -106,12 +106,6 @@
           <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
         </constraints>
       </vspacer>
-      <component id="7bc4a" class="com.intellij.ui.HideableTitledPanel" binding="myDebugOptionsHideablePanel" custom-create="true">
-        <constraints>
-          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
-        </constraints>
-        <properties/>
-      </component>
       <component id="b6d29" class="javax.swing.JCheckBox" binding="myUseRebarOutputPathsCheckbox">
         <constraints>
           <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -119,6 +113,12 @@
         <properties>
           <text value="Use rebar binaries paths (ebin, .eunit) instead of project compiler output"/>
         </properties>
+      </component>
+      <component id="7bc4a" class="com.intellij.ui.HideableTitledPanel" binding="myDebugOptionsHideablePanel" custom-create="true">
+        <constraints>
+          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="1" fill="1" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
       </component>
     </children>
   </grid>

--- a/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.java
+++ b/src/org/intellij/erlang/eunit/ui/ErlangUnitRunConfigurationEditorForm.java
@@ -45,6 +45,7 @@ public class ErlangUnitRunConfigurationEditorForm extends ErlangDebuggableRunCon
   @SuppressWarnings("unused")
   private HideableTitledPanel myDebugOptionsHideablePanel;
   private TextFieldWithBrowseButton myWorkingDirectoryComponent;
+  private JCheckBox myUseRebarOutputPathsCheckbox;
 
   public ErlangUnitRunConfigurationEditorForm() {
     myTestKindComboBox.addActionListener(e -> onTestKindSwitch());
@@ -71,6 +72,7 @@ public class ErlangUnitRunConfigurationEditorForm extends ErlangDebuggableRunCon
     myErlangModulesField.setText(getCommaSeparatedNamesString(configData.getModuleNames()));
     myErlangFunctionsField.setText(getCommaSeparatedNamesString(configData.getFunctionNames()));
     myWorkingDirectoryComponent.setText(StringUtil.notNullize(configuration.getWorkDirectory()));
+    myUseRebarOutputPathsCheckbox.setSelected(configData.isUseRebarPaths());
   }
 
   @Override
@@ -82,6 +84,7 @@ public class ErlangUnitRunConfigurationEditorForm extends ErlangDebuggableRunCon
     configData.setFunctionNames(parseCommaSeparatedNames(myErlangFunctionsField.getText()));
     configData.setModuleNames(parseCommaSeparatedNames(myErlangModulesField.getText()));
     configData.setKind((ErlangUnitRunConfiguration.ErlangUnitRunConfigurationKind) myTestKindComboBox.getSelectedItem());
+    configData.setUseRebarPaths(myUseRebarOutputPathsCheckbox.isSelected());
   }
 
   @NotNull

--- a/src/org/intellij/erlang/runconfig/ErlangRunConfigurationBase.java
+++ b/src/org/intellij/erlang/runconfig/ErlangRunConfigurationBase.java
@@ -122,11 +122,20 @@ public abstract class ErlangRunConfigurationBase<RunningState extends ErlangRunn
 
   public abstract boolean isUseTestCodePath();
 
+  public abstract boolean isUseRebarPaths();
+
   protected abstract RunningState newRunningState(ExecutionEnvironment env, Module module);
 
   public static final class ErlangDebugOptions implements Serializable {
+    public enum InterpretModulesLevel {
+      PROJECT,
+      DEPENDENCIES,
+      MODULE
+    };
+
     private boolean myAutoUpdateModulesNotToInterpret = true;
     private Set<String> myModulesNotToInterpret = new HashSet<>();
+    private InterpretModulesLevel myInterpretModulesLevel = InterpretModulesLevel.PROJECT;
 
     public boolean isAutoUpdateModulesNotToInterpret() {
       return myAutoUpdateModulesNotToInterpret;
@@ -145,6 +154,15 @@ public abstract class ErlangRunConfigurationBase<RunningState extends ErlangRunn
       myModulesNotToInterpret = modulesNotToInterpret;
     }
 
+    @NotNull
+    public InterpretModulesLevel getInterpretModulesLevel() {
+      return myInterpretModulesLevel;
+    }
+
+    public void setInterpretModulesLevel(@NotNull InterpretModulesLevel myInterpretModulesLevel) {
+      this.myInterpretModulesLevel = myInterpretModulesLevel;
+    }
+
     @Override
     public boolean equals(Object o) {
       if (this == o) return true;
@@ -154,6 +172,7 @@ public abstract class ErlangRunConfigurationBase<RunningState extends ErlangRunn
 
       if (myAutoUpdateModulesNotToInterpret != that.myAutoUpdateModulesNotToInterpret) return false;
       if (!myModulesNotToInterpret.equals(that.myModulesNotToInterpret)) return false;
+      if (myInterpretModulesLevel.equals(that.myInterpretModulesLevel)) return false;
 
       return true;
     }
@@ -161,7 +180,7 @@ public abstract class ErlangRunConfigurationBase<RunningState extends ErlangRunn
     @Override
     public int hashCode() {
       int result = (myAutoUpdateModulesNotToInterpret ? 1 : 0);
-      result = 31 * result + myModulesNotToInterpret.hashCode();
+      result = 31 * result + (myModulesNotToInterpret.hashCode() ^ myInterpretModulesLevel.hashCode());
       return result;
     }
   }

--- a/src/org/intellij/erlang/runconfig/ErlangRunningState.java
+++ b/src/org/intellij/erlang/runconfig/ErlangRunningState.java
@@ -70,7 +70,7 @@ public abstract class ErlangRunningState extends CommandLineState {
   }
 
   protected List<String> getCodePath() throws ExecutionException {
-    return ErlangConsoleUtil.getCodePath(myModule, useTestCodePath());
+    return ErlangConsoleUtil.getCodePath(myModule, useTestCodePath(), useRebarOutputPaths());
   }
 
   public Module getModule() {
@@ -78,6 +78,8 @@ public abstract class ErlangRunningState extends CommandLineState {
   }
 
   protected abstract boolean useTestCodePath();
+
+  protected abstract boolean useRebarOutputPaths();
 
   protected abstract boolean isNoShellMode();
 

--- a/src/org/intellij/erlang/runconfig/ui/ErlangDebugOptionsEditorForm.form
+++ b/src/org/intellij/erlang/runconfig/ui/ErlangDebugOptionsEditorForm.form
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form xmlns="http://www.intellij.com/uidesigner/form/" version="1" bind-to-class="org.intellij.erlang.runconfig.ui.ErlangDebugOptionsEditorForm">
-  <grid id="27dc6" binding="myContent" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+  <grid id="27dc6" binding="myContent" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
     <margin top="0" left="0" bottom="0" right="0"/>
     <constraints>
       <xy x="20" y="20" width="500" height="400"/>
@@ -11,7 +11,7 @@
       <grid id="4a83e" binding="myModulesNotToInterpretPanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
-          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+          <grid row="2" column="0" row-span="1" col-span="2" vsize-policy="7" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
         </constraints>
         <properties/>
         <border type="none"/>
@@ -19,7 +19,7 @@
       </grid>
       <component id="a5c44" class="com.intellij.ui.components.JBCheckBox" binding="myAutoUpdateModulesNotToInterpretCheckBox">
         <constraints>
-          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="9" fill="0" indent="1" use-parent-layout="false"/>
+          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="9" fill="0" indent="1" use-parent-layout="false"/>
         </constraints>
         <properties>
           <rolloverEnabled value="true"/>
@@ -27,6 +27,32 @@
           <toolTipText value="Auto-exclude modules containing calls to erlang:load_nif/2 from interpreted modules"/>
         </properties>
       </component>
+      <grid id="9d617" layout-manager="GridLayoutManager" row-count="1" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+        <margin top="0" left="0" bottom="0" right="0"/>
+        <constraints>
+          <grid row="0" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+        </constraints>
+        <properties/>
+        <border type="none"/>
+        <children>
+          <component id="6adcd" class="javax.swing.JLabel" binding="myInterpretModulesPolicyLabel">
+            <constraints>
+              <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <text value="Interpret modules:"/>
+            </properties>
+          </component>
+          <component id="38df7" class="javax.swing.JComboBox" binding="myInterpretModulesLevelComboBox">
+            <constraints>
+              <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="0" hsize-policy="2" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties>
+              <model/>
+            </properties>
+          </component>
+        </children>
+      </grid>
     </children>
   </grid>
 </form>

--- a/src/org/intellij/erlang/runconfig/ui/ErlangDebugOptionsEditorForm.java
+++ b/src/org/intellij/erlang/runconfig/ui/ErlangDebugOptionsEditorForm.java
@@ -21,10 +21,7 @@ import com.intellij.openapi.options.SettingsEditor;
 import com.intellij.openapi.ui.InputValidator;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.ui.CollectionListModel;
-import com.intellij.ui.IdeBorderFactory;
-import com.intellij.ui.ListUtil;
-import com.intellij.ui.ToolbarDecorator;
+import com.intellij.ui.*;
 import com.intellij.ui.components.JBCheckBox;
 import com.intellij.ui.components.JBList;
 import com.intellij.util.containers.ContainerUtil;
@@ -40,6 +37,9 @@ public class ErlangDebugOptionsEditorForm extends SettingsEditor<ErlangRunConfig
   private JPanel myContent;
   private JPanel myModulesNotToInterpretPanel;
   private JBCheckBox myAutoUpdateModulesNotToInterpretCheckBox;
+  private JComboBox myInterpretModulesLevelComboBox;
+  @SuppressWarnings("unused")
+  private JLabel myInterpretModulesPolicyLabel;
 
   private JBList myModulesNotToInterpretList;
   private CollectionListModel myModulesNotToInterpretListModel;
@@ -50,6 +50,15 @@ public class ErlangDebugOptionsEditorForm extends SettingsEditor<ErlangRunConfig
 
   @Override
   protected void resetEditorFrom(ErlangRunConfigurationBase.ErlangDebugOptions erlangDebugOptions) {
+    myInterpretModulesLevelComboBox.removeAllItems();
+    ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel[] levels = ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel.values();
+    for (ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel level : levels) {
+      //noinspection unchecked
+      myInterpretModulesLevelComboBox.addItem(level);
+    }
+    //noinspection unchecked
+    myInterpretModulesLevelComboBox.setRenderer(getInterpretModulesLevelListCellRendererWrapper());
+    myInterpretModulesLevelComboBox.setSelectedItem(erlangDebugOptions.getInterpretModulesLevel());
     myModulesNotToInterpretListModel.removeAll();
     for (String module : erlangDebugOptions.getModulesNotToInterpret()) {
       //noinspection unchecked
@@ -60,6 +69,8 @@ public class ErlangDebugOptionsEditorForm extends SettingsEditor<ErlangRunConfig
 
   @Override
   protected void applyEditorTo(ErlangRunConfigurationBase.ErlangDebugOptions erlangDebugOptions) throws ConfigurationException {
+    erlangDebugOptions.setInterpretModulesLevel(
+      (ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel) myInterpretModulesLevelComboBox.getSelectedItem());
     erlangDebugOptions.setAutoUpdateModulesNotToInterpret(myAutoUpdateModulesNotToInterpretCheckBox.isSelected());
     Set<String> modules = erlangDebugOptions.isAutoUpdateModulesNotToInterpret() ? Collections.<String>emptySet() :
       ContainerUtil.map2Set(myModulesNotToInterpretListModel.getItems(),
@@ -111,5 +122,27 @@ public class ErlangDebugOptionsEditorForm extends SettingsEditor<ErlangRunConfig
       .setMoveDownAction(null)
       .createPanel();
     myModulesNotToInterpretPanel.setBorder(IdeBorderFactory.createTitledBorder("Modules not to interpret", true));
+  }
+
+  private static ListCellRendererWrapper<ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel> getInterpretModulesLevelListCellRendererWrapper() {
+    return new ListCellRendererWrapper<ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel>() {
+      @Override
+      public void customize(JList list, ErlangRunConfigurationBase.ErlangDebugOptions.InterpretModulesLevel level, int index, boolean selected, boolean hasFocus) {
+        if (level == null) {
+          return;
+        }
+        switch (level) {
+          case PROJECT:
+            setText("All project");
+            break;
+          case DEPENDENCIES:
+            setText("Dependencies");
+            break;
+          case MODULE:
+            setText("Current module");
+            break;
+        }
+      }
+    };
   }
 }


### PR DESCRIPTION
Offer some rebar integration improvements:
- Boost debug session start time by selective modules interpreting.
- Check conent roots for rebar.config.script too.
- Valid Windows-specific file URLs handling ([like file://C:/../../](http://stackoverflow.com/questions/18520972/converting-java-file-url-to-file-path-platform-independent-including-u))
- Allow to specify custom config.rebar / config.rebar.script.
- Allow to use ebin / .eunit directories as module paths when running eunit configuration.
- Do not check for dirty files when rebar used, delegate it to rebar.
- Clean module before compile if forced build flag set.