### PR TITLE
bring back erlang build process messages

### DIFF
--- a/jps-plugin/src/org/intellij/erlang/jps/builder/ErlangCompilerError.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/builder/ErlangCompilerError.java
@@ -16,7 +16,7 @@
 
 package org.intellij.erlang.jps.builder;
 
-import com.intellij.openapi.compiler.CompilerMessageCategory;
+import org.jetbrains.jps.incremental.messages.BuildMessage;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.openapi.vfs.VfsUtilCore;
@@ -37,16 +37,16 @@ public class ErlangCompilerError {
   private final String myErrorMessage;
   private final String myUrl;
   private final int myLine;
-  private final CompilerMessageCategory myCategory;
+  private final BuildMessage.Kind myKind;
 
   private ErlangCompilerError(@NotNull String errorMessage,
                               @NotNull String url,
                               int line,
-                              @NotNull CompilerMessageCategory category) {
+                              @NotNull BuildMessage.Kind category) {
     this.myErrorMessage = errorMessage;
     this.myUrl = url;
     this.myLine = line;
-    this.myCategory = category;
+    this.myKind = category;
   }
 
   @NotNull
@@ -64,8 +64,8 @@ public class ErlangCompilerError {
   }
 
   @NotNull
-  public CompilerMessageCategory getCategory() {
-    return myCategory;
+  public BuildMessage.Kind getKind() {
+    return myKind;
   }
 
   @Nullable
@@ -89,7 +89,7 @@ public class ErlangCompilerError {
                                                          @Nullable String warning,
                                                          @NotNull String details) {
     int lineNumber = StringUtil.parseInt(line, -1);
-    CompilerMessageCategory category = warning != null ? CompilerMessageCategory.WARNING : CompilerMessageCategory.ERROR;
+    BuildMessage.Kind category = warning != null ? BuildMessage.Kind.WARNING : BuildMessage.Kind.ERROR;
     return new ErlangCompilerError(details, VfsUtilCore.pathToUrl(filePath), lineNumber, category);
   }
 }

--- a/jps-plugin/src/org/intellij/erlang/jps/builder/ErlangCompilerProcessAdapter.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/builder/ErlangCompilerProcessAdapter.java
@@ -17,7 +17,6 @@
 package org.intellij.erlang.jps.builder;
 
 import com.intellij.execution.process.ProcessEvent;
-import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.vfs.VirtualFileManager;
 import org.jetbrains.annotations.NotNull;
@@ -48,8 +47,7 @@ public class ErlangCompilerProcessAdapter extends BuilderProcessAdapter {
 
     ErlangCompilerError error = ErlangCompilerError.create(compileTargetRootPath, text);
     if (error != null) {
-      boolean isError = error.getCategory() == CompilerMessageCategory.ERROR;
-      kind = isError ? BuildMessage.Kind.ERROR : BuildMessage.Kind.WARNING;
+      kind = error.getKind();
       messageText = error.getErrorMessage();
       sourcePath = VirtualFileManager.extractPath(error.getUrl());
       line = error.getLine();

--- a/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarMessage.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarMessage.java
@@ -16,7 +16,7 @@
 
 package org.intellij.erlang.jps.rebar;
 
-import com.intellij.openapi.compiler.CompilerMessageCategory;
+import org.jetbrains.jps.incremental.messages.BuildMessage;
 import com.intellij.openapi.util.text.StringUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -26,11 +26,11 @@ import java.util.regex.Pattern;
 
 public class RebarMessage {
   private static final Pattern LOG_MESSAGE_PATTERN = Pattern.compile("(ERROR|WARN|INFO|DEBUG):(.+)");
-  private final CompilerMessageCategory myCategory;
+  private final BuildMessage.Kind myKind;
   private final String myDetails;
 
-  private RebarMessage(@NotNull CompilerMessageCategory category, @NotNull String details) {
-    this.myCategory = category;
+  private RebarMessage(@NotNull BuildMessage.Kind category, @NotNull String details) {
+    this.myKind = category;
     this.myDetails = details;
   }
 
@@ -41,12 +41,12 @@ public class RebarMessage {
 
     String type = matcher.group(1);
     String details = matcher.group(2);
-    return new RebarMessage(findCategory(type), details);
+    return new RebarMessage(findKind(type), details);
   }
 
   @NotNull
-  public CompilerMessageCategory getCategory() {
-    return myCategory;
+  public BuildMessage.Kind getKind() {
+    return myKind;
   }
 
   @NotNull
@@ -55,13 +55,13 @@ public class RebarMessage {
   }
 
   @NotNull
-  private static CompilerMessageCategory findCategory(@NotNull String type) {
+  private static BuildMessage.Kind findKind(@NotNull String type) {
     if ("ERROR".equals(type)) {
-      return CompilerMessageCategory.ERROR;
+      return BuildMessage.Kind.ERROR;
     }
     if ("WARN".equals(type)) {
-      return CompilerMessageCategory.WARNING;
+      return BuildMessage.Kind.WARNING;
     }
-    return CompilerMessageCategory.INFORMATION;
+    return BuildMessage.Kind.INFO;
   }
 }

--- a/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarProcessAdapter.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarProcessAdapter.java
@@ -17,13 +17,11 @@
 package org.intellij.erlang.jps.rebar;
 
 import com.intellij.execution.process.ProcessEvent;
-import com.intellij.openapi.compiler.CompilerMessageCategory;
 import com.intellij.openapi.util.Key;
 import org.intellij.erlang.jps.builder.BuilderProcessAdapter;
 import org.intellij.erlang.jps.builder.ErlangCompilerProcessAdapter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.jps.incremental.CompileContext;
-import org.jetbrains.jps.incremental.messages.BuildMessage;
 import org.jetbrains.jps.incremental.messages.CompilerMessage;
 
 public class RebarProcessAdapter extends BuilderProcessAdapter {
@@ -55,7 +53,7 @@ public class RebarProcessAdapter extends BuilderProcessAdapter {
   @NotNull
   private CompilerMessage createCompilerMessage(@NotNull String messageText) {
     RebarMessage message = RebarMessage.create(messageText);
-    return message != null ? new CompilerMessage(myBuilderName, getKind(message.getCategory()), message.getDetails())
+    return message != null ? new CompilerMessage(myBuilderName, message.getKind(), message.getDetails())
                            : getDefaultCompilerMessage(messageText);
   }
 
@@ -72,21 +70,6 @@ public class RebarProcessAdapter extends BuilderProcessAdapter {
     myMessageBuilder.append(messagePart.trim());
   }
 
-  @NotNull
-  private static BuildMessage.Kind getKind(@NotNull CompilerMessageCategory category) {
-    switch (category) {
-      case ERROR:
-        return BuildMessage.Kind.ERROR;
-      case WARNING:
-        return BuildMessage.Kind.WARNING;
-      case INFORMATION:
-        return BuildMessage.Kind.INFO;
-      case STATISTICS:
-        return BuildMessage.Kind.PROGRESS;
-      default:
-        throw new AssertionError();
-    }
-  }
 
   private static boolean isMessageContinue(@NotNull String messagePart) {
     return messagePart.isEmpty() || Character.isWhitespace(messagePart.charAt(0));


### PR DESCRIPTION
After upgrading to 2018.1 the Erlang build errors and warnings are not displayed anymore.
Even if the compilation fails it looks like that everything succeeded, but no beam files get generated

The reason for this is:

`java.lang.NoClassDefFoundError: com/intellij/openapi/compiler/CompilerMessageCategory`

This replaces `CompilerMessageCategory` with `BuildMessage.Kind`	