### PR TITLE
fix generation of path to rebar.config

### DIFF
--- a/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
+++ b/jps-plugin/src/org/intellij/erlang/jps/rebar/RebarBuilder.java
@@ -37,10 +37,10 @@ import org.jetbrains.jps.model.JpsDummyElement;
 import org.jetbrains.jps.model.JpsProject;
 import org.jetbrains.jps.model.library.sdk.JpsSdk;
 import org.jetbrains.jps.model.module.JpsModule;
+import org.jetbrains.jps.util.JpsPathUtil;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collections;
 
@@ -75,8 +75,8 @@ public class RebarBuilder extends TargetBuilder<ErlangSourceRootDescriptor, Erla
     String escriptPath = JpsErlangSdkType.getScriptInterpreterExecutable(sdk.getHomePath()).getAbsolutePath();
     boolean isRebarRun = false;
     for (String contentRootUrl : module.getContentRootsList().getUrls()) {
-      String contentRootPath = new URL(contentRootUrl).getPath();
-      File contentRootDir = new File(contentRootPath);
+      String contentRootPath = JpsPathUtil.urlToPath(contentRootUrl);
+      File contentRootDir = JpsPathUtil.urlToFile(contentRootUrl);
       File rebarConfigFile = new File(contentRootDir, REBAR_CONFIG_FILE_NAME);
       if (!rebarConfigFile.exists()) continue;
       runRebar(escriptPath, rebarPath, contentRootPath, compilerOptions.myAddDebugInfoEnabled, context);


### PR DESCRIPTION
URLs from `module.getContentRootsList().getUrls()` come in the following form `file://X:/Devel/testing/test` (since they are defined as  `<content url="file://$MODULE_DIR$">` in the iml file)
But java.net.URL expects URLs with drive letters with an extra `'/'` like `file:///X:/Devel/testing/test`

`(new URL("file:///X:/Devel/testing/test").getPath()` returns `X:\Devel\testing\test`
but
`(new URL("file://X:/Devel/testing/test").getPath()` returns `\Devel\testing\test`

This makes the drive letter of the module's rebar.config dependant on the installation directory of IntelliJ.
If both the project and IntelliJ are on the same drive, everything works as expected, otherwise the plugin will look for rebar.config in a completely wrong location (the drive where IntelliJ is installed) and error with "rebar.config not found" message.

**TL;DR**
Fixes locating problems locating rebar.config on Windows

