### PR TITLE
try rebar3 version check without escript first

### DIFF
--- a/src/org/intellij/erlang/rebar/settings/RebarConfigurationForm.java
+++ b/src/org/intellij/erlang/rebar/settings/RebarConfigurationForm.java
@@ -81,8 +81,7 @@ public class RebarConfigurationForm {
     File rebarFile = new File(rebarPath);
     if (!rebarFile.exists()) return false;
 
-    String escript = RebarRunningStateUtil.findEscriptExecutable();
-    ExtProcessUtil.ExtProcessOutput output = ExtProcessUtil.execAndGetFirstLine(3000, escript, rebarPath, "--version");
+    ExtProcessUtil.ExtProcessOutput output = ExtProcessUtil.execAndGetFirstLine(3000, rebarPath, "--version");
     String version = output.getStdOut();
 
     if (version.startsWith("rebar")) {
@@ -90,8 +89,22 @@ public class RebarConfigurationForm {
       return true;
     }
 
+    String escript = RebarRunningStateUtil.findEscriptExecutable();
+    ExtProcessUtil.ExtProcessOutput outputWithEscript = ExtProcessUtil.execAndGetFirstLine(3000, escript, rebarPath, "--version");
+    String versionWithEscript = output.getStdOut();
+
+    if (versionWithEscript.startsWith("rebar")) {
+      myRebarVersionText.setText(versionWithEscript);
+      return true;
+    }
+
     String stdErr = output.getStdErr();
-    myRebarVersionText.setText("N/A" + (StringUtil.isNotEmpty(stdErr) ? ": Error: " + stdErr : ""));
+    String stdErrWithEscript = outputWithEscript.getStdErr();
+
+    String errMessage = StringUtil.isNotEmpty(stdErr) ? ": Error: " + stdErr : "";
+    errMessage += StringUtil.isNotEmpty(stdErrWithEscript) ? ": ErrorWithEscript: " + stdErrWithEscript : "";
+    myRebarVersionText.setText("N/A" + errMessage);
+
     return false;
   }
 


### PR DESCRIPTION
the plugin tries to run this:
```
$ escript ~/.cache/rebar3/bin/rebar3 --version
~/.cache/rebar3/bin/rebar3:3: syntax error before: '-'
escript: There were compilation errors.
```

but it works for my like this
```
$ ~/.cache/rebar3/bin/rebar3 --version
rebar 3.11.1 on Erlang/OTP 22 Erts 10.4.3
```