### PR TITLE
Variables used as width in binary patterns cannot create a variable declaration

### DIFF
--- a/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
+++ b/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
@@ -510,6 +510,21 @@ public class ErlangPsiImplUtil {
     return PsiTreeUtil.getParentOfType(psiElement, ErlangColonQualifiedExpression.class) != null;
   }
 
+  /**
+   * Check whether expression is used in a binary expression after the colon, like \<\<_:Var\>\>
+   * @param psiElement
+   * @return
+   */
+  public static boolean isBinaryWidthExpression(PsiElement psiElement) {
+    ErlangMaxExpression maxParent = PsiTreeUtil.getParentOfType(psiElement, ErlangMaxExpression.class);
+    if (maxParent == null) return false;
+
+    PsiElement prevSib = PsiTreeUtil.getPrevSiblingOfType(maxParent, PsiElement.class);
+    if (prevSib == null) return false;
+
+    return prevSib.getText().equals(":");
+  }
+
   public static boolean inLeftPartOfAssignment(@NotNull PsiElement psiElement) {
     return inLeftPartOfAssignment(psiElement, true);
   }

--- a/testData/find-usages/binaryWidthIsNotAVarDef.erl
+++ b/testData/find-usages/binaryWidthIsNotAVarDef.erl
@@ -1,0 +1,23 @@
+%% Copyright 2019 Dmytro Lytovchenko <dmytro.lytovchenko@gmail.com>, Sergey Ignatov
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(binaryWidthIsNotAVarDef).
+
+-export([bwidthNotVar/2]).
+
+bwidthNotVar(Var<caret>, Var2) ->
+  %% Variable used to the right of Binary Width in a binary pattern cannot be a new variable declaration,
+  %% so Var should have 2 usages: below in binary width and below in X+Var and not just 1 usage
+  <<X:Var, _/binary>> = Var2,
+  X + Var.

--- a/tests/org/intellij/erlang/findUsages/ErlangFindUsagesTest.java
+++ b/tests/org/intellij/erlang/findUsages/ErlangFindUsagesTest.java
@@ -26,6 +26,7 @@ public class ErlangFindUsagesTest extends ErlangLightPlatformCodeInsightFixtureT
 
   public void testFunctionUsagesInSingleFile()    { doTest(4); }
   public void testFunctionUsagesInMultipleFiles() { doTest(5, "functionUsagesInSingleFile.erl");}
+  public void testBinaryWidthIsNotAVarDef()       { doTest(2, "binaryWidthIsNotAVarDef.erl");}
 
 //TODO enable these tests when reference search will make use of custom WordsScanner implementations
 //  public void testEmptyAtomFunctionInSingleFile()    { doTest(2); }


### PR DESCRIPTION
Closes #888

The code checks whether a `QVar` is found inside a MaxExpression and is preceded by a `':'` and is on the left side of an assignment, in that case, the `QVar` cannot become a declaration.
