### PR TITLE
Quote record field completions if necessary

### DIFF
--- a/src/org/intellij/erlang/completion/ErlangCompletionContributor.java
+++ b/src/org/intellij/erlang/completion/ErlangCompletionContributor.java
@@ -255,7 +255,10 @@ public class ErlangCompletionContributor extends CompletionContributor {
   }
 
   private static LookupElement createFieldLookupElement(@NotNull Project project, @NotNull String text, boolean withoutEq) {
-    return LookupElementBuilder.create(text)
+    String maybeQuotedText = ErlangPsiImplUtil.needQuotation(text)
+                             ? "'" + text + "'"
+                             : text;
+    return LookupElementBuilder.create(maybeQuotedText)
                                .withIcon(ErlangIcons.FIELD)
                                .withInsertHandler(withoutEq ? null : equalsInsertHandler(project));
   }

--- a/tests/org/intellij/erlang/completion/ErlangCompletionTest.java
+++ b/tests/org/intellij/erlang/completion/ErlangCompletionTest.java
@@ -91,6 +91,13 @@ public class ErlangCompletionTest extends ErlangCompletionTestBase {
         "bar(A, B)-> A#foo{two = }");
   }
 
+  public void testRecordFields7() {
+    doTestInclude(
+      "-record(foo, {id, 'WeirdCase', 'strange-symbol'}).\n" +
+      "bar(A, B)-> A#foo{<caret>}",
+      "id", "'WeirdCase'", "'strange-symbol'");
+  }
+
   public void testMacros() {
     doTestInclude(
       "-define(foo, 1).\n" +


### PR DESCRIPTION
When listing and selecting record fields for completion, fields which need quoting were not quoted.
This change quotes them.