### PR TITLE
Bump Gradle [wrapper] to 6.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.jetbrains.intellij' version "0.4.10"
+  id 'org.jetbrains.intellij' version "0.4.20"
 }
 
 version = "${version}.$buildNumber"
@@ -72,4 +72,8 @@ idea {
   module {
     generatedSourceDirs += file('gen')
   }
+}
+
+runIde {
+  jvmArgs '-Xmx1024M'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
-  id 'org.jetbrains.intellij' version "0.4.19"
+  id 'java'
+  id 'org.jetbrains.intellij' version '0.4.20'
 }
 
 version = "${version}.$buildNumber"
@@ -7,7 +8,11 @@ allprojects {
   apply plugin: 'java'
   sourceCompatibility = javaVersion
   targetCompatibility = javaVersion
-  tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
+  tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+    // To enable linting of deprecation warnings:
+    // options.compilerArgs.add("-Xlint:all")
+  }
 
   sourceSets {
     main {
@@ -53,6 +58,7 @@ allprojects {
 }
 
 repositories {
+  mavenCentral()
   flatDir {
     dirs 'libs'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.jetbrains.intellij' version "0.4.20"
+  id 'org.jetbrains.intellij' version "0.4.19"
 }
 
 version = "${version}.$buildNumber"

--- a/build.gradle
+++ b/build.gradle
@@ -59,8 +59,8 @@ repositories {
 }
 
 dependencies {
-  compile name: 'OtpErlang'
-  compile project('jps-plugin')
+  compileOnly name: 'OtpErlang'
+  implementation project('jps-plugin')
 }
 
 apply plugin: 'idea'

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,4 +10,4 @@ buildNumber = SNAPSHOT
 sources = true
 isEAP = false
 localIdePath = 
-org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+CMSPermGenSweepingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
+org.gradle.jvmargs=-XX:MaxPermSize=512m -XX:+CMSClassUnloadingEnabled -XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-bin.zip

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,1 +1,1 @@
-jar.archiveName = "jps-plugin.jar"
+jar.archiveFileName = "jps-plugin.jar"

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,1 +1,5 @@
 jar.archiveFileName = "jps-plugin.jar"
+
+repositories {
+  mavenCentral()
+}


### PR DESCRIPTION
Currently used Gradle [wrapper] version does not support recent JDK versions such as JDK 13.

This is tangentially related to #884.