### PR TITLE
Fix #918: ref() is not a valid Erlang type, new name is reference()

### DIFF
--- a/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
+++ b/src/org/intellij/erlang/psi/impl/ErlangPsiImplUtil.java
@@ -87,7 +87,7 @@ public class ErlangPsiImplUtil {
   public static final Set<String> BUILT_IN_TYPES = ContainerUtil.set(
     "any", "atom", "boolean", "byte", "char", "float", "integer", "iolist", "list", "maybe_improper_list", "mfa",
     "module", "neg_integer", "no_return", "node", "non_neg_integer", "none", "nonempty_string", "number", "pid", "port",
-    "pos_integer", "ref", "string", "term", "timeout"
+    "pos_integer", "reference", "string", "term", "timeout"
   );
   public static final Key<LanguageConsoleImpl> ERLANG_CONSOLE = Key.create("ERLANG_CONSOLE");
 


### PR DESCRIPTION
`ref()` type was removed and became `reference()` in at least 2011
Change commit https://github.com/erlang/otp/blob/8853793b0edd01947829840f90c91a1e2468cc36/erts/doc/src/notes.xml#L1904