### PR TITLE
fix can't resolve rebar version problem; fix sdk string mismatching

### DIFF
--- a/src/org/intellij/erlang/rebar/settings/RebarConfigurationForm.java
+++ b/src/org/intellij/erlang/rebar/settings/RebarConfigurationForm.java
@@ -95,7 +95,7 @@ public class RebarConfigurationForm {
 
         String escriptPath = RebarRunningStateUtil.findEscriptExecutable();
         ExtProcessUtil.ExtProcessOutput escript = ExtProcessUtil.execAndGetFirstLine(3000, escriptPath, rebarPath, "--version");
-        String versionWithEscript = rebar.getStdOut();
+        String versionWithEscript = escript.getStdOut();
 
         if (versionWithEscript.startsWith("rebar")) {
           updateUI(consumer, versionWithEscript);

--- a/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
+++ b/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
@@ -31,7 +31,7 @@ public final class ErlangSdkRelease {
   public static final ErlangSdkRelease V_17_0 = new ErlangSdkRelease("17", "6.0");
   public static final ErlangSdkRelease V_18_0 = new ErlangSdkRelease("18", "7.0");
 
-  private static final Pattern VERSION_PATTERN = Pattern.compile("Erlang/OTP (\\S+) \\[erts-(\\S+)]");
+  private static final Pattern VERSION_PATTERN = Pattern.compile("OTP (\\S+), erts-(\\S+)");
 
   private final String myOtpRelease;
   private final String myErtsVersion;


### PR DESCRIPTION
---
fix #903
like issue said can't resolve rebar version problem on windows, seems just should use `escript.getStdOut()` not `rebar.getStdOut()`

https://github.com/ignatov/intellij-erlang/blob/8eb5f46096284707776a0e4b4594e86a57ee2df5/src/org/intellij/erlang/rebar/settings/RebarConfigurationForm.java#L97-L98
 
---
after this comit 0dfb40ea7a36b0a8e6987993a2f5ccc6d99a78c3[simplify visible erlang sdk name]
should also change patten
https://github.com/ignatov/intellij-erlang/blob/0dfb40ea7a36b0a8e6987993a2f5ccc6d99a78c3/src/org/intellij/erlang/sdk/ErlangSdkRelease.java#L34
https://github.com/ignatov/intellij-erlang/blob/0dfb40ea7a36b0a8e6987993a2f5ccc6d99a78c3/src/org/intellij/erlang/sdk/ErlangSdkRelease.java#L63-L64

or ErlangSdkType.detectSdkVersion will always call erl, but not all time can use OSProcessHandler, it will make error `ERROR - ution.process.OSProcessHandler - Synchronous execution on EDT`
