### PR TITLE
Bump dependencies versions; Bump JDK to 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,9 +9,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 11
+    - name: Set up JDK 17
       uses: actions/setup-java@v1
       with:
-        java-version: 11
+        java-version: 17
     - name: Build with Gradle
       run: ./gradlew clean test

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,7 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="USE_SAME_INDENTS" value="true" />
-    <option name="IGNORE_SAME_INDENTS_FOR_LANGUAGES" value="true" />
     <option name="OTHER_INDENT_OPTIONS">
       <value>
         <option name="INDENT_SIZE" value="2" />
@@ -14,9 +12,6 @@
       <option name="FIELD_NAME_PREFIX" value="my" />
       <option name="ALIGN_MULTILINE_ANNOTATION_PARAMETERS" value="true" />
     </JavaCodeStyleSettings>
-    <XML>
-      <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true" />
-    </XML>
     <ADDITIONAL_INDENT_OPTIONS fileType="scala">
       <option name="INDENT_SIZE" value="2" />
       <option name="TAB_SIZE" value="2" />

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,7 +6,7 @@
       <entry name="!?*.java" />
       <entry name="!?*.form" />
     </wildcardResourcePatterns>
-    <bytecodeTargetLevel target="11">
+    <bytecodeTargetLevel target="17">
       <module name="Erlang_main" target="1.8" />
       <module name="Erlang_test" target="1.8" />
       <module name="intellij-erlang_main" target="1.8" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="false" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="corretto-11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
 </project>

--- a/.idea/runConfigurations/Local_IDE.xml
+++ b/.idea/runConfigurations/Local_IDE.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Local IDE" type="GradleRunConfiguration" factoryName="Gradle" singleton="true">
-    <log_file path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -11,11 +11,14 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value=":runIdea" />
+          <option value=":runIde" />
         </list>
       </option>
       <option name="vmOptions" value="-Dorg.gradle.project.localIdePath=&quot;/Applications/WebStorm.app&quot;" />
     </ExternalSystemSettings>
-    <method />
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
   </configuration>
 </component>

--- a/build.gradle
+++ b/build.gradle
@@ -35,9 +35,9 @@ allprojects {
     downloadSources = Boolean.valueOf(sources)
     sameSinceUntilBuild = Boolean.valueOf(isEAP)
   }
-  
+
   def compilationPackages = ['org/intellij/erlang/build/**', 'org/intellij/erlang/jps/**']
-  
+
   test {
     useJUnitPlatform {
       exclude compilationPackages
@@ -81,4 +81,8 @@ idea {
   module {
     generatedSourceDirs += file('gen')
   }
+}
+
+runIde {
+  jvmArgs '-Xmx1536M'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 plugins {
-  id 'org.jetbrains.intellij' version "1.8.0"
+  id 'org.jetbrains.intellij' version "1.9.0"
 }
 
 dependencies {
-  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.6.1'
-  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.1'
-  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.1'
+  testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.9.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
   testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.6.1'
-  testCompileOnly 'junit:junit:4.13'
+  testCompileOnly 'junit:junit:4.13.2'
 }
 
 version = "${version}.$buildNumber"
@@ -15,7 +15,7 @@ allprojects {
   repositories { mavenCentral() }
   apply plugin: 'java'
   sourceCompatibility = javaVersion
-  targetCompatibility = javaVersion
+  targetCompatibility = javaTargetVersion
   tasks.withType(JavaCompile) { options.encoding = 'UTF-8' }
 
   sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ buildNumber=SNAPSHOT
 sources=true
 isEAP=false
 localIdePath=
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=utf-8
 org.gradle.caching=true
 org.gradle.vfs.watch=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 # Available idea versions: 
 # https://www.jetbrains.com/intellij-repository/releases
 # https://www.jetbrains.com/intellij-repository/snapshots
-
-version = 0.11
-ideaVersion = 2022.2
-javaVersion = 11
-javaTargetVersion = 11
-buildNumber = SNAPSHOT
-sources = true
-isEAP = false
-localIdePath =
+version=0.11
+ideaVersion=2022.2
+javaVersion=17
+javaTargetVersion=17
+buildNumber=SNAPSHOT
+sources=true
+isEAP=false
+localIdePath=
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
-org.gradle.caching = true
-org.gradle.vfs.watch = true
+org.gradle.caching=true
+org.gradle.vfs.watch=true
+org.gradle.parallel=true

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -1,1 +1,1 @@
-jar.archiveName = "jps-plugin.jar"
+jar.archiveFileName = "jps-plugin.jar"


### PR DESCRIPTION
- Gradle bump dependency versions for Intellij Gradle plugin and test libs
- JDK bump version to 17
- Github Actions CI bump JDK to 17
- Up :runIde memory to 1.5GB (default 0.5GB too small)
- Change option for JPS gradle from `jar.archiveName` to `jar.archiveFileName`