### PR TITLE
Allow characters ($integer) notation in typespecs

### DIFF
--- a/gen/org/intellij/erlang/parser/ErlangParser.java
+++ b/gen/org/intellij/erlang/parser/ErlangParser.java
@@ -3140,7 +3140,7 @@ public class ErlangParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // '-'? (integer | macros argument_list?)
+  // '-'? (integer | macros argument_list? | char)
   public static boolean int_type(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "int_type")) return false;
     boolean r;
@@ -3158,13 +3158,14 @@ public class ErlangParser implements PsiParser, LightPsiParser {
     return true;
   }
 
-  // integer | macros argument_list?
+  // integer | macros argument_list? | char
   private static boolean int_type_1(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "int_type_1")) return false;
     boolean r;
     Marker m = enter_section_(b);
     r = consumeToken(b, ERL_INTEGER);
     if (!r) r = int_type_1_1(b, l + 1);
+    if (!r) r = consumeToken(b, ERL_CHAR);
     exit_section_(b, m, null, r);
     return r;
   }

--- a/gen/org/intellij/erlang/psi/ErlangIntType.java
+++ b/gen/org/intellij/erlang/psi/ErlangIntType.java
@@ -17,6 +17,9 @@ public interface ErlangIntType extends ErlangType {
   PsiElement getOpMinus();
 
   @Nullable
+  PsiElement getChar();
+
+  @Nullable
   PsiElement getInteger();
 
 }

--- a/gen/org/intellij/erlang/psi/impl/ErlangIntTypeImpl.java
+++ b/gen/org/intellij/erlang/psi/impl/ErlangIntTypeImpl.java
@@ -47,6 +47,12 @@ public class ErlangIntTypeImpl extends ErlangTypeImpl implements ErlangIntType {
 
   @Override
   @Nullable
+  public PsiElement getChar() {
+    return findChildByType(ERL_CHAR);
+  }
+
+  @Override
+  @Nullable
   public PsiElement getInteger() {
     return findChildByType(ERL_INTEGER);
   }

--- a/grammars/erlang.bnf
+++ b/grammars/erlang.bnf
@@ -291,7 +291,7 @@ type ::=
   | map_type {pin(".*")=1}
 record_like_type ::= '{' top_type_list? '}'
 
-int_type ::= '-'? (integer | macros argument_list?)
+int_type ::= '-'? (integer | macros argument_list? | char)
 fun_type_100_t ::= '(' ('...' | top_type_list?) ')' top_type_clause {extends=type pin(".*")=1}
 fun_type ::= fun_type_arguments top_type_clause {extends=type pin=1}
 top_type_clause ::= '->' top_type {pin=1}


### PR DESCRIPTION
Fixes #996
Allows $N notation in integer ranges of typespecs