### PR TITLE
Parse fun in lambdas and fun in function references as different tokens

### DIFF
--- a/.idea/runConfigurations/Local_IDE.xml
+++ b/.idea/runConfigurations/Local_IDE.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Local IDE" type="GradleRunConfiguration" factoryName="Gradle" singleton="true">
-    <log_file path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" checked="true" skipped="true" show_all="false" alias="idea.log" />
+    <log_file alias="idea.log" path="$PROJECT_DIR$/build/idea-sandbox/system/log/idea.log" />
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -11,11 +11,14 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value=":runIdea" />
+          <option value=":runIde" />
         </list>
       </option>
       <option name="vmOptions" value="-Dorg.gradle.project.localIdePath=&quot;/Applications/WebStorm.app&quot;" />
     </ExternalSystemSettings>
-    <method />
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <method v="2" />
   </configuration>
 </component>

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ allprojects {
   apply plugin: 'org.jetbrains.intellij'
   intellij {
     version = ideaVersion
-    plugins = ['copyright', 'java']
+    plugins = ['copyright', 'java', psiViewerPlugin]
     downloadSources = Boolean.valueOf(sources)
     sameSinceUntilBuild = Boolean.valueOf(isEAP)
   }
@@ -57,6 +57,9 @@ allprojects {
     systemProperties = [
       "erlang.sdk.path": System.getProperty("erlang.sdk.path")
     ]
+    runIde {
+      jvmArgs '-Xmx2G'
+    }
   }
 }
 

--- a/gen/org/intellij/erlang/ErlangTypes.java
+++ b/gen/org/intellij/erlang/ErlangTypes.java
@@ -60,6 +60,7 @@ public interface ErlangTypes {
   IElementType ERL_FUN_CLAUSE = new ErlangCompositeElementType("ERL_FUN_CLAUSE");
   IElementType ERL_FUN_CLAUSES = new ErlangCompositeElementType("ERL_FUN_CLAUSES");
   IElementType ERL_FUN_EXPRESSION = new ErlangCompositeElementType("ERL_FUN_EXPRESSION");
+  IElementType ERL_FUN_REF_EXPRESSION = new ErlangCompositeElementType("ERL_FUN_REF_EXPRESSION");
   IElementType ERL_FUN_TYPE = new ErlangCompositeElementType("ERL_FUN_TYPE");
   IElementType ERL_FUN_TYPE_100_T = new ErlangCompositeElementType("ERL_FUN_TYPE_100_T");
   IElementType ERL_FUN_TYPE_ARGUMENTS = new ErlangCompositeElementType("ERL_FUN_TYPE_ARGUMENTS");
@@ -365,6 +366,9 @@ public interface ErlangTypes {
       }
       else if (type == ERL_FUN_EXPRESSION) {
         return new ErlangFunExpressionImpl(node);
+      }
+      else if (type == ERL_FUN_REF_EXPRESSION) {
+        return new ErlangFunRefExpressionImpl(node);
       }
       else if (type == ERL_FUN_TYPE) {
         return new ErlangFunTypeImpl(node);

--- a/gen/org/intellij/erlang/psi/ErlangFunExpression.java
+++ b/gen/org/intellij/erlang/psi/ErlangFunExpression.java
@@ -9,23 +9,8 @@ import com.intellij.psi.scope.PsiScopeProcessor;
 
 public interface ErlangFunExpression extends ErlangExpression {
 
-  @Nullable
+  @NotNull
   ErlangFunClauses getFunClauses();
-
-  @Nullable
-  ErlangFunctionWithArity getFunctionWithArity();
-
-  @Nullable
-  ErlangFunctionWithArityVariables getFunctionWithArityVariables();
-
-  @Nullable
-  ErlangModuleRef getModuleRef();
-
-  @Nullable
-  ErlangQVar getQVar();
-
-  @Nullable
-  PsiElement getColon();
 
   @Nullable
   PsiElement getEnd();

--- a/gen/org/intellij/erlang/psi/ErlangFunRefExpression.java
+++ b/gen/org/intellij/erlang/psi/ErlangFunRefExpression.java
@@ -1,0 +1,32 @@
+// This is a generated file. Not intended for manual editing.
+package org.intellij.erlang.psi;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.psi.PsiElement;
+
+public interface ErlangFunRefExpression extends ErlangExpression {
+
+  @Nullable
+  ErlangFunctionWithArity getFunctionWithArity();
+
+  @Nullable
+  ErlangFunctionWithArityVariables getFunctionWithArityVariables();
+
+  @Nullable
+  ErlangModuleRef getModuleRef();
+
+  @Nullable
+  ErlangQVar getQVar();
+
+  @Nullable
+  PsiElement getColon();
+
+  @NotNull
+  PsiElement getFun();
+
+  //WARNING: processDeclarations(...) is skipped
+  //matching processDeclarations(ErlangFunRefExpression, ...)
+  //methods are not found in ErlangPsiImplUtil
+
+}

--- a/gen/org/intellij/erlang/psi/ErlangVisitor.java
+++ b/gen/org/intellij/erlang/psi/ErlangVisitor.java
@@ -192,6 +192,10 @@ public class ErlangVisitor extends PsiElementVisitor {
     visitExpression(o);
   }
 
+  public void visitFunRefExpression(@NotNull ErlangFunRefExpression o) {
+    visitExpression(o);
+  }
+
   public void visitFunType(@NotNull ErlangFunType o) {
     visitType(o);
   }

--- a/gen/org/intellij/erlang/psi/impl/ErlangFunExpressionImpl.java
+++ b/gen/org/intellij/erlang/psi/impl/ErlangFunExpressionImpl.java
@@ -30,39 +30,9 @@ public class ErlangFunExpressionImpl extends ErlangExpressionImpl implements Erl
   }
 
   @Override
-  @Nullable
+  @NotNull
   public ErlangFunClauses getFunClauses() {
-    return PsiTreeUtil.getChildOfType(this, ErlangFunClauses.class);
-  }
-
-  @Override
-  @Nullable
-  public ErlangFunctionWithArity getFunctionWithArity() {
-    return PsiTreeUtil.getChildOfType(this, ErlangFunctionWithArity.class);
-  }
-
-  @Override
-  @Nullable
-  public ErlangFunctionWithArityVariables getFunctionWithArityVariables() {
-    return PsiTreeUtil.getChildOfType(this, ErlangFunctionWithArityVariables.class);
-  }
-
-  @Override
-  @Nullable
-  public ErlangModuleRef getModuleRef() {
-    return PsiTreeUtil.getChildOfType(this, ErlangModuleRef.class);
-  }
-
-  @Override
-  @Nullable
-  public ErlangQVar getQVar() {
-    return PsiTreeUtil.getChildOfType(this, ErlangQVar.class);
-  }
-
-  @Override
-  @Nullable
-  public PsiElement getColon() {
-    return findChildByType(ERL_COLON);
+    return notNullChild(PsiTreeUtil.getChildOfType(this, ErlangFunClauses.class));
   }
 
   @Override

--- a/gen/org/intellij/erlang/psi/impl/ErlangFunRefExpressionImpl.java
+++ b/gen/org/intellij/erlang/psi/impl/ErlangFunRefExpressionImpl.java
@@ -1,0 +1,66 @@
+// This is a generated file. Not intended for manual editing.
+package org.intellij.erlang.psi.impl;
+
+import java.util.List;
+import org.jetbrains.annotations.*;
+import com.intellij.lang.ASTNode;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementVisitor;
+import com.intellij.psi.util.PsiTreeUtil;
+import static org.intellij.erlang.ErlangTypes.*;
+import org.intellij.erlang.psi.*;
+
+public class ErlangFunRefExpressionImpl extends ErlangExpressionImpl implements ErlangFunRefExpression {
+
+  public ErlangFunRefExpressionImpl(ASTNode node) {
+    super(node);
+  }
+
+  @Override
+  public void accept(@NotNull ErlangVisitor visitor) {
+    visitor.visitFunRefExpression(this);
+  }
+
+  @Override
+  public void accept(@NotNull PsiElementVisitor visitor) {
+    if (visitor instanceof ErlangVisitor) accept((ErlangVisitor)visitor);
+    else super.accept(visitor);
+  }
+
+  @Override
+  @Nullable
+  public ErlangFunctionWithArity getFunctionWithArity() {
+    return PsiTreeUtil.getChildOfType(this, ErlangFunctionWithArity.class);
+  }
+
+  @Override
+  @Nullable
+  public ErlangFunctionWithArityVariables getFunctionWithArityVariables() {
+    return PsiTreeUtil.getChildOfType(this, ErlangFunctionWithArityVariables.class);
+  }
+
+  @Override
+  @Nullable
+  public ErlangModuleRef getModuleRef() {
+    return PsiTreeUtil.getChildOfType(this, ErlangModuleRef.class);
+  }
+
+  @Override
+  @Nullable
+  public ErlangQVar getQVar() {
+    return PsiTreeUtil.getChildOfType(this, ErlangQVar.class);
+  }
+
+  @Override
+  @Nullable
+  public PsiElement getColon() {
+    return findChildByType(ERL_COLON);
+  }
+
+  @Override
+  @NotNull
+  public PsiElement getFun() {
+    return notNullChild(findChildByType(ERL_FUN));
+  }
+
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,12 +4,13 @@
 
 version = 0.11
 ideaVersion = 223.7571-EAP-CANDIDATE-SNAPSHOT
+psiViewerPlugin = PsiViewer:2022.3
 javaVersion = 17
 javaTargetVersion = 17
 buildNumber = SNAPSHOT
 sources = true
 isEAP = false
 localIdePath =
-org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xmx1024m -Dfile.encoding=utf-8
+org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=utf-8
 org.gradle.caching = true
 org.gradle.vfs.watch = true

--- a/grammars/erlang.bnf
+++ b/grammars/erlang.bnf
@@ -375,7 +375,7 @@ config_argument_list ::= '(' config_exprs? ')' {elementType=argument_list}
 config_list_expression ::= '[' config_exprs? ']' {elementType=list_expression}
 config_bin_list_expression ::= '<<' config_exprs? '>>' {elementType=binary_expression}
 config_tuple_expression ::= '{' config_exprs? '}' {elementType=tuple_expression}
-config_fun_expression ::= fun fun_expression_lambda {elementType=fun_expression pin=1}
+config_fun_expression ::= fun !'(' fun_ref_expression_body {elementType=fun_expression pin=1}
 
 config_map_construct_expression ::= config_map_tuple {elementType=map_expression}
 config_map_tuple ::= '#' '{' config_map_assoc_list? '}' {pin=1 elementType=map_tuple}
@@ -438,7 +438,7 @@ max_expression ::=
   | map_comprehension
   | map_construct_expression
   | receive_expression
-  | fun_expression
+  | fun_expression | fun_ref_expression
   | try_expression
   | maybe_expression
   | binary_expression
@@ -555,8 +555,9 @@ argument_definition ::= expression
 receive_expression ::= receive (after_clause | cr_clauses after_clause? ) end {pin(".*")=1}
 private after_clause ::= after after_clause_body {pin=1}
 after_clause_body ::= <<guarded expression>> clause_body {pin=1}
-fun_expression ::= fun (fun_expression_block | fun_expression_lambda) {pin=1 methods=[processDeclarations]}
-private fun_expression_lambda ::= [(module_ref | q_var) ':'] (function_with_arity | function_with_arity_variables)
+fun_expression ::= fun &'(' fun_expression_block {pin=3 methods=[processDeclarations]}
+fun_ref_expression ::= fun !'(' fun_ref_expression_body {pin=3 methods=[processDeclarations]}
+private fun_ref_expression_body ::= [(module_ref | q_var) ':'] (function_with_arity | function_with_arity_variables)
 private fun_expression_block ::= fun_clauses end {pin=1}
 
 function_with_arity ::= q_atom '/' integer {pin=1 methods=[getReference]}


### PR DESCRIPTION
Fixes #990

* Split BNF definitions for fun[clause+]end, and M:F/Arity reference (just for clarity)
* Split ERL_FUN="fun" token into two: "fun" followed by a "(" for regular function definitions, and ERL_FUN2 = "fun" followed by a letter for function reference expressions: `fun mod:func/arity`.
* Modify the highlighting to color ERL_FUN2 as a keyword