### PR TITLE
Tokenize 'maybe' as an atom before OTP 25

### DIFF
--- a/gen/org/intellij/erlang/parser/_ErlangLexer.java
+++ b/gen/org/intellij/erlang/parser/_ErlangLexer.java
@@ -3,8 +3,11 @@
 package org.intellij.erlang.parser;
 import com.intellij.lexer.FlexLexer;
 import com.intellij.psi.tree.IElementType;
+import org.intellij.erlang.sdk.ErlangSdkRelease;
 import static org.intellij.erlang.ErlangTypes.*;
 import static org.intellij.erlang.ErlangParserDefinition.*;
+import org.intellij.erlang.sdk.ErlangSdkType;import org.jetbrains.annotations.Nullable;
+import com.intellij.openapi.project.Project;
 
 
 /**
@@ -383,9 +386,13 @@ public class _ErlangLexer implements FlexLexer {
   private boolean zzEOFDone;
 
   /* user code: */
-  public _ErlangLexer() {
-    this((java.io.Reader)null);
-  }
+    // Used by the tokenizer to request language features to be enabled
+    public Project project = null;
+
+    public _ErlangLexer(@Nullable Project project_) {
+      this((java.io.Reader)null);
+      this.project = project_;
+    }
 
 
   /**
@@ -1023,7 +1030,8 @@ public class _ErlangLexer implements FlexLexer {
             // fall through
           case 160: break;
           case 79: 
-            { return ERL_MAYBE;
+            { boolean isSupported = ErlangSdkType.getRelease(this.project).erlangFeatureMaybe();
+        return isSupported ? ERL_MAYBE : ERL_ATOM_NAME;
             } 
             // fall through
           case 161: break;

--- a/src/org/intellij/erlang/ErlangParserDefinition.java
+++ b/src/org/intellij/erlang/ErlangParserDefinition.java
@@ -47,7 +47,7 @@ public class ErlangParserDefinition implements ParserDefinition {
   @NotNull
   @Override
   public Lexer createLexer(Project project) {
-    return new ErlangLexer();
+    return new ErlangLexer(project);
   }
 
   @Override

--- a/src/org/intellij/erlang/parser/Erlang.flex
+++ b/src/org/intellij/erlang/parser/Erlang.flex
@@ -1,15 +1,22 @@
 package org.intellij.erlang.parser;
 import com.intellij.lexer.FlexLexer;
 import com.intellij.psi.tree.IElementType;
+import org.intellij.erlang.sdk.ErlangSdkRelease;
 import static org.intellij.erlang.ErlangTypes.*;
 import static org.intellij.erlang.ErlangParserDefinition.*;
+import org.intellij.erlang.sdk.ErlangSdkType;import org.jetbrains.annotations.Nullable;
+import com.intellij.openapi.project.Project;
 
 %%
 
 %{
-  public _ErlangLexer() {
-    this((java.io.Reader)null);
-  }
+    // Used by the tokenizer to request language features to be enabled
+    public Project project = null;
+
+    public _ErlangLexer(@Nullable Project project_) {
+      this((java.io.Reader)null);
+      this.project = project_;
+    }
 %}
 
 %class _ErlangLexer
@@ -91,7 +98,10 @@ Variable = (_ {NameChars}) | ({ErlangUppercase} {NameChars})
 <YYINITIAL> "catch"                       { return ERL_CATCH; }
 <YYINITIAL> "if"                          { return ERL_IF; }
 <YYINITIAL> "receive"                     { return ERL_RECEIVE; }
-<YYINITIAL> "maybe"                       { return ERL_MAYBE; }
+<YYINITIAL> "maybe"                       {
+        boolean isSupported = ErlangSdkType.getRelease(this.project).erlangFeatureMaybe();
+        return isSupported ? ERL_MAYBE : ERL_ATOM_NAME;
+      }
 <YYINITIAL> "else"                        { return ERL_ELSE; }
 
 <YYINITIAL> ":="                          { return ERL_MATCH; }

--- a/src/org/intellij/erlang/parser/ErlangLexer.java
+++ b/src/org/intellij/erlang/parser/ErlangLexer.java
@@ -19,17 +19,21 @@ package org.intellij.erlang.parser;
 import com.intellij.lexer.FlexAdapter;
 import com.intellij.lexer.LookAheadLexer;
 import com.intellij.lexer.MergingLexerAdapter;
+import com.intellij.openapi.project.Project;
 import com.intellij.psi.tree.TokenSet;
+import org.eclipse.sisu.Nullable;
 
 import static org.intellij.erlang.ErlangParserDefinition.COMMENTS;
 import static org.intellij.erlang.ErlangTypes.*;
 
 public class ErlangLexer extends LookAheadLexer {
   public static final TokenSet KEYWORDS = TokenSet.create(
-    ERL_AFTER, ERL_WHEN, ERL_BEGIN, ERL_END, ERL_OF, ERL_CASE, ERL_FUN, ERL_CATCH, ERL_IF, ERL_RECEIVE, ERL_TRY,
-    ERL_ELSE, ERL_MAYBE);
+    ERL_AFTER, ERL_WHEN, ERL_BEGIN, ERL_END, ERL_OF, ERL_CASE, ERL_FUN, ERL_CATCH, ERL_IF, ERL_RECEIVE, ERL_TRY, ERL_ELSE,
+    // The MAYBE keyword will only be parsed as keyword if SDK release is 25+, otherwise will be an atom
+    ERL_MAYBE
+  );
 
-  public ErlangLexer() {
-    super(new MergingLexerAdapter(new FlexAdapter(new _ErlangLexer()), COMMENTS));
+  public ErlangLexer(@Nullable Project project) {
+    super(new MergingLexerAdapter(new FlexAdapter(new _ErlangLexer(project)), COMMENTS));
   }
 }

--- a/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
+++ b/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
@@ -32,11 +32,18 @@ public final class ErlangSdkRelease {
   public static final ErlangSdkRelease V_18_0 = new ErlangSdkRelease("18", "7.0");
   public static final ErlangSdkRelease V_25_0 = new ErlangSdkRelease("25", "13.0");
 
+  // The release with most features, assumed to be in effect if the version cannot be determined. The parser will use
+  // this to guess the features available in the Erlang SDK.
+  public static final ErlangSdkRelease DefaultRelease = V_25_0;
+
   private static final Pattern VERSION_PATTERN = Pattern.compile("Erlang/OTP (\\S+) \\[erts-(\\S+)]");
   private static final Pattern NEW_VERSION_PATTERN = Pattern.compile("OTP (\\S+), erts-(\\S+)");
 
   private final String myOtpRelease;
   private final String myErtsVersion;
+
+  // Cached value of Erlang version 25 or greater
+  private Boolean haveErlang25 = null;
 
   public ErlangSdkRelease(@NotNull String otpRelease, @NotNull String ertsVersion) {
     myOtpRelease = otpRelease;
@@ -76,5 +83,18 @@ public final class ErlangSdkRelease {
       }
     }
     return null;
+  }
+
+  // True if Erlang of this version supports 'maybe' as a keyword, otherwise it is parsed as atom.
+  private boolean erlangIsAtLeast25() {
+    if (haveErlang25 != null) {
+      return haveErlang25;
+    }
+    this.haveErlang25 = VersionComparatorUtil.compare(myErtsVersion, "25") >= 0;
+    return haveErlang25;
+  }
+
+  public boolean erlangFeatureMaybe() {
+    return this.erlangIsAtLeast25();
   }
 }


### PR DESCRIPTION
Closes #1009

Need good review

Need assistance, because this has several problems
1. Switching SDK does not regenerate the editor with feature disabled or enabled, IDEA restart works. Need to invalidate all results of lexer somehow, when SDK changes.
2. Need a project instance to pass to `new ErlangLexer()` in
    1. org/intellij/erlang/search/ErlangFindUsagesProvider.java
    2. org/intellij/erlang/editor/ErlangSyntaxHighlighter.java