### PR TITLE
Fixed Issue #1024

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # https://www.jetbrains.com/intellij-repository/snapshots
 
 version = 0.11
-ideaVersion = 241.14494-EAP-CANDIDATE-SNAPSHOT
+ideaVersion = 241.18034.62
 javaVersion = 17
 javaTargetVersion = 17
 buildNumber = SNAPSHOT

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/org/intellij/erlang/rebar/importWizard/SelectImportedOtpAppsStep.java
+++ b/src/org/intellij/erlang/rebar/importWizard/SelectImportedOtpAppsStep.java
@@ -20,13 +20,13 @@ import com.intellij.ide.util.ElementsChooser;
 import com.intellij.ide.util.projectWizard.WizardContext;
 import com.intellij.openapi.options.ConfigurationException;
 import com.intellij.projectImport.SelectImportedProjectsStep;
-import com.intellij.vcsUtil.VcsFileUtil;
+// import com.intellij.vcsUtil.VcsFileUtil;
 import org.intellij.erlang.icons.ErlangIcons;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
-import java.io.File;
+// import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -67,10 +67,8 @@ final class SelectImportedOtpAppsStep extends SelectImportedProjectsStep<Importe
   }
 
   @Override
-  protected String getElementText(@NotNull ImportedOtpApp app) {
-    String projectFileDirectory = getWizardContext().getProjectFileDirectory();
-    String relativePath = VcsFileUtil.relativePath(new File(projectFileDirectory), app.getRoot());
-    return ".".equals(relativePath) ? relativePath + " (" + app.getName() + ")" : relativePath;
+  protected String getElementText(@NotNull ImportedOtpApp importedOtpApp) {
+    return importedOtpApp.toString();
   }
 
   @Nullable


### PR DESCRIPTION
Fixed: Issue #1024 in function copyBeamTo
Changed: Upgrade gradle version to 8.5
Changed: Upgrade idea version to stable 241 release
Changed: Reverted getElementText function to older version because of missing VcsFileUtil library

The debugger beam files could not be found with the ResourceUtil library. Instead we get the inputStream now from the class itself. 

Tested with Erlang 25.X