### PR TITLE
Fix EDT violation when opening Rebar project in IntelliJ 2025.3

### DIFF
--- a/src/org/intellij/erlang/rebar/importWizard/RebarProjectImportBuilder.java
+++ b/src/org/intellij/erlang/rebar/importWizard/RebarProjectImportBuilder.java
@@ -136,8 +136,10 @@ public class RebarProjectImportBuilder extends ProjectImportBuilder<ImportedOtpA
     
     myProjectRoot = projectRoot;
 
-    ProgressManager.getInstance().run(new Task.Modal(getCurrentProject(), "Scanning Rebar Projects", true) {
-      public void run(@NotNull final ProgressIndicator indicator) {
+    Project currentProject = ApplicationManager.getApplication().isDispatchThread()
+                             ? getCurrentProject()
+                             : null;
+    ProgressManager.getInstance().run(new Task.Backgroundable(currentProject, "Scanning Rebar Projects", true) {      public void run(@NotNull final ProgressIndicator indicator) {
         if (!unitTestMode && projectRoot instanceof VirtualDirectoryImpl) {
           ((VirtualDirectoryImpl) projectRoot).refreshAndFindChild("deps");
           ((VirtualDirectoryImpl) projectRoot).refreshAndFindChild("_build");

--- a/src/org/intellij/erlang/rebar/importWizard/RebarProjectOpenProcessor.java
+++ b/src/org/intellij/erlang/rebar/importWizard/RebarProjectOpenProcessor.java
@@ -17,6 +17,7 @@
 package org.intellij.erlang.rebar.importWizard;
 
 import com.intellij.ide.util.projectWizard.WizardContext;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.projectImport.ProjectOpenProcessorBase;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +31,7 @@ public class RebarProjectOpenProcessor extends ProjectOpenProcessorBase<RebarPro
   public boolean doQuickImport(@NotNull VirtualFile configFile, @NotNull WizardContext wizardContext) {
     VirtualFile projectRoot = configFile.getParent();
     wizardContext.setProjectName(projectRoot.getName());
-    getBuilder().setProjectRoot(projectRoot);
+    ApplicationManager.getApplication().invokeAndWait(() -> getBuilder().setProjectRoot(projectRoot));
     return true;
   }
 


### PR DESCRIPTION
<!-- Provide a brief summary of your changes -->

## Motivation and Context
<!-- Why is this change needed? What problem does it solve? -->
Opening a Rebar project causes IDE to freeze due to EDT violation. 
doQuickImport and setProjectRoot were calling UI code from a background thread.
## How Has This Been Tested?
<!-- Have you tested this in a real application? Which scenarios were tested? -->
Tested manually by opening a Rebar project in IntelliJ 2025.3 on Linux.

## Breaking Changes
<!-- Will users need to update their code or configurations? -->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [ ] My code follows the repository's style guidelines
- [ ] New and existing tests pass locally
- [ ] I have added appropriate error handling
- [ ] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
