### PR TITLE
Add Erlang OTP 27+ sigil string support

### DIFF
--- a/gen/org/intellij/erlang/ErlangTypes.java
+++ b/gen/org/intellij/erlang/ErlangTypes.java
@@ -209,6 +209,7 @@ public interface ErlangTypes {
   IElementType ERL_RECEIVE = new ErlangTokenType("receive");
   IElementType ERL_REM = new ErlangTokenType("rem");
   IElementType ERL_SEMI = new ErlangTokenType(";");
+  IElementType ERL_SIGIL_STRING = new ErlangTokenType("sigil_string");
   IElementType ERL_SINGLE_QUOTE = new ErlangTokenType("single_quote");
   IElementType ERL_STRING = new ErlangTokenType("string");
   IElementType ERL_TRIPLE_QUOTED_STRING = new ErlangTokenType("triple_quoted_string");

--- a/gen/org/intellij/erlang/parser/ErlangParser.java
+++ b/gen/org/intellij/erlang/parser/ErlangParser.java
@@ -2346,7 +2346,7 @@ public class ErlangParser implements PsiParser, LightPsiParser {
     return r;
   }
 
-  // '+' | '-' | '<<' | '?' | '[' | '{' | atom_name | single_quote | bnot | char | float | integer | not | string | var | '#' | '.'
+  // '+' | '-' | '<<' | '?' | '[' | '{' | atom_name | single_quote | bnot | char | float | integer | not | string | sigil_string | var | '#' | '.'
   private static boolean form_recover_0(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "form_recover_0")) return false;
     boolean r;
@@ -2364,6 +2364,7 @@ public class ErlangParser implements PsiParser, LightPsiParser {
     if (!r) r = consumeToken(b, ERL_INTEGER);
     if (!r) r = consumeToken(b, ERL_NOT);
     if (!r) r = consumeToken(b, ERL_STRING);
+    if (!r) r = consumeToken(b, ERL_SIGIL_STRING);
     if (!r) r = consumeToken(b, ERL_VAR);
     if (!r) r = consumeToken(b, ERL_RADIX);
     if (!r) r = consumeToken(b, ERL_DOT);
@@ -4985,14 +4986,15 @@ public class ErlangParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // string | triple_quoted_string
+  // string | triple_quoted_string | sigil_string
   public static boolean string_literal(PsiBuilder b, int l) {
     if (!recursion_guard_(b, l, "string_literal")) return false;
-    if (!nextTokenIs(b, "<expression>", ERL_STRING, ERL_TRIPLE_QUOTED_STRING)) return false;
+    if (!nextTokenIs(b, "<expression>", ERL_SIGIL_STRING, ERL_STRING, ERL_TRIPLE_QUOTED_STRING)) return false;
     boolean r;
     Marker m = enter_section_(b, l, _NONE_, ERL_STRING_LITERAL, "<expression>");
     r = consumeToken(b, ERL_STRING);
     if (!r) r = consumeToken(b, ERL_TRIPLE_QUOTED_STRING);
+    if (!r) r = consumeToken(b, ERL_SIGIL_STRING);
     exit_section_(b, l, m, r, false, null);
     return r;
   }

--- a/gen/org/intellij/erlang/psi/ErlangStringLiteral.java
+++ b/gen/org/intellij/erlang/psi/ErlangStringLiteral.java
@@ -15,6 +15,9 @@ public interface ErlangStringLiteral extends ErlangExpression, PsiLanguageInject
   @Nullable
   PsiElement getTripleQuotedString();
 
+  @Nullable
+  PsiElement getSigilString();
+
   boolean isValidHost();
 
   @NotNull ErlangStringLiteral updateText(@NotNull String text);

--- a/gen/org/intellij/erlang/psi/impl/ErlangStringLiteralImpl.java
+++ b/gen/org/intellij/erlang/psi/impl/ErlangStringLiteralImpl.java
@@ -41,6 +41,12 @@ public class ErlangStringLiteralImpl extends ErlangExpressionImpl implements Erl
   }
 
   @Override
+  @Nullable
+  public PsiElement getSigilString() {
+    return findChildByType(ERL_SIGIL_STRING);
+  }
+
+  @Override
   public boolean isValidHost() {
     return ErlangPsiImplUtil.isValidHost(this);
   }

--- a/grammars/erlang.bnf
+++ b/grammars/erlang.bnf
@@ -93,7 +93,7 @@ private console_expression_or_empty ::= exprs period | empty {pin(".*")=1}
 private empty ::= ()
 private form_with_period ::= form period {recoverWhile=form_recover pin=1}
 private left period ::= '.' | <<isModeOn "ELSE">> <<exitMode "ELSE">>
-private form_recover ::= !('+' | '-' | '<<' | '?' | '[' | '{' | atom_name | single_quote | bnot | char | float | integer | not | string | var | '#' | '.')
+private form_recover ::= !('+' | '-' | '<<' | '?' | '[' | '{' | atom_name | single_quote | bnot | char | float | integer | not | string | sigil_string | var | '#' | '.')
 private form ::=
     is_config config_expression
   | function
@@ -591,7 +591,7 @@ private exprs_tail ::= ',' expression {pin=1 recoverWhile=exprs_recover}
 private exprs_recover ::= !(')' | ',' | '->' | '.' | ':-' | ';' | '}' | after | catch | else | end | of | atom '(')
 guard ::= exprs (';' exprs)* {pin(".*")=1}
 private atomic ::= q_atom !'(' | integer | (string_literal | macros)+ | float | char
-string_literal ::= string | triple_quoted_string {
+string_literal ::= string | triple_quoted_string | sigil_string {
   implements = "com.intellij.psi.PsiLanguageInjectionHost"
   methods = [isValidHost updateText createLiteralTextEscaper]
 }

--- a/src/org/intellij/erlang/ErlangParserDefinition.java
+++ b/src/org/intellij/erlang/ErlangParserDefinition.java
@@ -42,7 +42,9 @@ public class ErlangParserDefinition implements ParserDefinition {
   public static final IElementType ERL_FUNCTION_DOC_COMMENT = new ErlangTokenType("function_doc_comment");
   public static final IElementType ERL_MODULE_DOC_COMMENT = new ErlangTokenType("module_doc_comment");
   public static final TokenSet COMMENTS = TokenSet.create(ERL_COMMENT, ERL_FUNCTION_DOC_COMMENT, ERL_MODULE_DOC_COMMENT, ERL_SHEBANG);
-  private static final TokenSet LITERALS = TokenSet.create(ErlangTypes.ERL_STRING);
+  private static final TokenSet LITERALS = TokenSet.create(
+    ErlangTypes.ERL_STRING, ErlangTypes.ERL_TRIPLE_QUOTED_STRING, ErlangTypes.ERL_SIGIL_STRING
+  );
 
   @NotNull
   @Override

--- a/src/org/intellij/erlang/ErlangStringLiteralEscaper.java
+++ b/src/org/intellij/erlang/ErlangStringLiteralEscaper.java
@@ -47,6 +47,10 @@ public class ErlangStringLiteralEscaper extends LiteralTextEscaper<ErlangStringL
 
   @Override
   public boolean isOneLine() {
+    String text = myHost.getText();
+    if (text.startsWith("\"\"\"") || text.startsWith("~")) {
+      return false;
+    }
     return true;
   }
 }

--- a/src/org/intellij/erlang/editor/ErlangSyntaxHighlighter.java
+++ b/src/org/intellij/erlang/editor/ErlangSyntaxHighlighter.java
@@ -77,7 +77,7 @@ public class ErlangSyntaxHighlighter extends SyntaxHighlighterBase {
     if (ErlangParserDefinition.COMMENTS.contains(type)) {
       return pack(COMMENT);
     }
-    if (type == ERL_STRING || type == ERL_CHAR) {
+    if (type == ERL_STRING || type == ERL_CHAR || type == ERL_TRIPLE_QUOTED_STRING || type == ERL_SIGIL_STRING) {
       return pack(STRING);
     }
     if (type == ERL_INTEGER || type == ERL_FLOAT) {

--- a/src/org/intellij/erlang/inspection/Erlang27SyntaxInspection.java
+++ b/src/org/intellij/erlang/inspection/Erlang27SyntaxInspection.java
@@ -27,6 +27,9 @@ public class Erlang27SyntaxInspection extends ErlangInspectionBase {
         if (text.startsWith("\"\"\"") || text.endsWith("\"\"\"")) {
           holder.registerProblem(o, "Triple quotes are only supported in Erlang 27 and newer versions");
         }
+        else if (text.startsWith("~")) {
+          holder.registerProblem(o, "Sigils are only supported in Erlang 27 and newer versions");
+        }
       }
     };
   }

--- a/src/org/intellij/erlang/parser/Erlang.flex
+++ b/src/org/intellij/erlang/parser/Erlang.flex
@@ -71,6 +71,21 @@ STRING_BAD1 = \" ({CHAR} | \') *
 TripleQuotedString = \"\"\" ([^\"] | \"[^\"] | \"\"[^\"])* \"\"\"
 StringLiteral = {TripleQuotedString} | {STRING_BAD1} \"
 
+/* Sigil strings (OTP 27+) */
+SigilPrefix = "~" [bBsS]?
+SigilPairedParen = {SigilPrefix} "(" ([^)] | "\\)")* ")"
+SigilPairedBracket = {SigilPrefix} "[" ([^\]] | "\\]")* "]"
+SigilPairedBrace = {SigilPrefix} "{" ([^}] | "\\}")* "}"
+SigilPairedAngle = {SigilPrefix} "<" ([^>] | "\\>")* ">"
+SigilSymSlash = {SigilPrefix} "/" ([^/] | "\\/")* "/"
+SigilSymPipe = {SigilPrefix} "|" ([^|] | "\\|")* "|"
+SigilSymSQuote = {SigilPrefix} "'" ([^'] | "\\'")* "'"
+SigilSymDQuote = {SigilPrefix} "\"" ({CHAR} | \')* "\""
+SigilSymBacktick = {SigilPrefix} "`" ([^`] | "\\`")* "`"
+SigilSymHash = {SigilPrefix} "#" ([^#] | "\\#")* "#"
+SigilTripleQuoted = {SigilPrefix} {TripleQuotedString}
+SigilString = {SigilTripleQuoted} | {SigilPairedParen} | {SigilPairedBracket} | {SigilPairedBrace} | {SigilPairedAngle} | {SigilSymSlash} | {SigilSymPipe} | {SigilSymSQuote} | {SigilSymDQuote} | {SigilSymBacktick} | {SigilSymHash}
+
 NameChar = {ErlangLetter} | {ErlangDigit} | @ | _
 NameChars = {NameChar}*
 
@@ -147,6 +162,7 @@ Variable = (_ {NameChars}) | ({ErlangUppercase} {NameChars})
 <YYINITIAL> {FloatLiteral}                { return ERL_FLOAT; }
 
 <YYINITIAL> {CharLiteral}                 { return ERL_CHAR; }
+<YYINITIAL> {SigilString}                 { return ERL_SIGIL_STRING; }
 <YYINITIAL> {StringLiteral}               { return ERL_STRING; }
 <YYINITIAL> {TripleQuotedString}          { return ERL_TRIPLE_QUOTED_STRING; }
 

--- a/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
+++ b/src/org/intellij/erlang/sdk/ErlangSdkRelease.java
@@ -104,4 +104,8 @@ public final class ErlangSdkRelease {
   public boolean erlangFeatureMaybe() {
     return this.erlangIsAtLeast25();
   }
+
+  public boolean erlangFeatureSigils() {
+    return this.isNewerOrEqualTo(V_27_0);
+  }
 }

--- a/testData/highlighting/Erlang27SyntaxNoError.erl
+++ b/testData/highlighting/Erlang27SyntaxNoError.erl
@@ -1,4 +1,4 @@
--export([quotes/0, single_line/0, bad_indent/0]).
+-export([quotes/0, single_line/0, bad_indent/0, sigils/0]).
 
 quotes() ->
   """
@@ -13,3 +13,9 @@ single_line() ->
 bad_indent() ->
   <error>"""
   main"""</error>.
+
+sigils() ->
+    ~"hello",
+    ~b(binary),
+    ~S[verbatim],
+    ok.

--- a/tests/org/intellij/erlang/highlighting/Erlang27HighlightingTest.java
+++ b/tests/org/intellij/erlang/highlighting/Erlang27HighlightingTest.java
@@ -21,4 +21,9 @@ public class Erlang27HighlightingTest extends ErlangHighlightingTestBase {
     enableErlang27SyntaxInspection();
     doTest();
   }
+
+  public void testSigilStrings() {
+    enableErlang27SyntaxInspection();
+    doTest();
+  }
 }

--- a/tests/org/intellij/erlang/highlighting/Erlang27SmallIdeHighlightingTest.java
+++ b/tests/org/intellij/erlang/highlighting/Erlang27SmallIdeHighlightingTest.java
@@ -50,4 +50,9 @@ public class Erlang27SmallIdeHighlightingTest extends ErlangHighlightingTestBase
     enableErlang27SyntaxInspection();
     doTest();
   }
+
+  public void testSigilStrings() {
+    enableErlang27SyntaxInspection();
+    doTest();
+  }
 }

--- a/tests/org/intellij/erlang/highlighting/ErlangHighlightingTest.java
+++ b/tests/org/intellij/erlang/highlighting/ErlangHighlightingTest.java
@@ -140,4 +140,9 @@ public class ErlangHighlightingTest extends ErlangHighlightingTestBase {
 
   public void testFunctionImportFromTransitiveInclusion() { doTestWithApp(); }
   public void testFunctionImportFromInclusion()           { doTestWithApp(); }
+
+  public void testSigilSyntaxError() {
+    enableErlang27SyntaxInspection();
+    doTest();
+  }
 }

--- a/tests/org/intellij/erlang/parser/ErlangParserTest.java
+++ b/tests/org/intellij/erlang/parser/ErlangParserTest.java
@@ -99,4 +99,5 @@ public class ErlangParserTest extends ErlangParserTestBase {
   public void testTypo()                                { doTest(true);  }
   public void testNewNumbers()                          { doTest(true);  }
   public void testTripleQuotes()                        { doTest(true);  }
+  public void testSigilStrings()                        { doTest(false); }
 }


### PR DESCRIPTION

## Motivation and Context
support string feature
https://www.erlang.org/doc/system/data_types.html#sigil
fixes #1046 

## How Has This Been Tested?
Unit tests are updated 

## Breaking Changes
No

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have read the [MCP Documentation](https://modelcontextprotocol.io)
- [x] My code follows the repository's style guidelines
- [x] New and existing tests pass locally
- [x] I have added appropriate error handling
- [x] I have added or updated documentation as needed

## Additional context
<!-- Add any other context, implementation notes, or design decisions -->
